### PR TITLE
Introduce Atoms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to deser are documented here.
+
+## 0.4.0
+
+- Restructure serialization and deserialization to pass `Atom` values
+  within `Event` and `Chunk`.  This changes the interface from invoking
+  type specific methods on the sink to passing an entire `Atom` instead.
+- Events are now passed by value rather than reference.

--- a/deser-debug/src/lib.rs
+++ b/deser-debug/src/lib.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::sync::atomic::{self, AtomicUsize};
 
 use deser::ser::{for_each_event, Serialize};
-use deser::Event;
+use deser::{Atom, Event};
 
 /// Serializes a serializable value to `Debug` format.
 pub struct ToDebug {
@@ -42,10 +42,10 @@ fn dump<'a, 'f>(
 ) -> Result<&'a [(Event<'a>, Option<String>)], fmt::Error> {
     if let Some((first, mut rest)) = tokens.split_first() {
         match first.0 {
-            Event::Null => fmt::Debug::fmt(&(), f)?,
-            Event::Bool(v) => fmt::Debug::fmt(&v, f)?,
-            Event::Str(ref v) => fmt::Debug::fmt(v, f)?,
-            Event::Bytes(ref v) => {
+            Event::Atom(Atom::Null) => fmt::Debug::fmt(&(), f)?,
+            Event::Atom(Atom::Bool(v)) => fmt::Debug::fmt(&v, f)?,
+            Event::Atom(Atom::Str(ref v)) => fmt::Debug::fmt(v, f)?,
+            Event::Atom(Atom::Bytes(ref v)) => {
                 write!(f, "b\"")?;
                 for &b in &v[..] {
                     if b == b'\n' {
@@ -66,9 +66,9 @@ fn dump<'a, 'f>(
                 }
                 write!(f, "\"")?;
             }
-            Event::U64(v) => fmt::Debug::fmt(&v, f)?,
-            Event::I64(v) => fmt::Debug::fmt(&v, f)?,
-            Event::F64(v) => fmt::Debug::fmt(&v, f)?,
+            Event::Atom(Atom::U64(v)) => fmt::Debug::fmt(&v, f)?,
+            Event::Atom(Atom::I64(v)) => fmt::Debug::fmt(&v, f)?,
+            Event::Atom(Atom::F64(v)) => fmt::Debug::fmt(&v, f)?,
             Event::MapStart => {
                 if let Some(ref name) = first.1 {
                     write!(f, "{} ", name)?;

--- a/deser-path/src/de.rs
+++ b/deser-path/src/de.rs
@@ -3,7 +3,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use deser::de::{DeserializerState, MapSink, SeqSink, Sink, SinkHandle};
-use deser::Error;
+use deser::{Atom, Error};
 
 use crate::{Path, PathSegment};
 
@@ -35,39 +35,9 @@ impl<'a> PathSink<'a> {
 }
 
 impl<'a> Sink for PathSink<'a> {
-    fn null(&mut self, state: &DeserializerState) -> Result<(), Error> {
+    fn atom(&mut self, atom: Atom, state: &DeserializerState) -> Result<(), Error> {
         self.set_segment(state);
-        self.sink.null(state)
-    }
-
-    fn bool(&mut self, value: bool, state: &DeserializerState) -> Result<(), Error> {
-        self.set_segment(state);
-        self.sink.bool(value, state)
-    }
-
-    fn str(&mut self, value: &str, state: &DeserializerState) -> Result<(), Error> {
-        self.set_segment(state);
-        self.sink.str(value, state)
-    }
-
-    fn bytes(&mut self, value: &[u8], state: &DeserializerState) -> Result<(), Error> {
-        self.set_segment(state);
-        self.sink.bytes(value, state)
-    }
-
-    fn u64(&mut self, value: u64, state: &DeserializerState) -> Result<(), Error> {
-        self.set_segment(state);
-        self.sink.u64(value, state)
-    }
-
-    fn i64(&mut self, value: i64, state: &DeserializerState) -> Result<(), Error> {
-        self.set_segment(state);
-        self.sink.i64(value, state)
-    }
-
-    fn f64(&mut self, value: f64, state: &DeserializerState) -> Result<(), Error> {
-        self.set_segment(state);
-        self.sink.f64(value, state)
+        self.sink.atom(atom, state)
     }
 
     fn map(&mut self, state: &DeserializerState) -> Result<Box<dyn MapSink + '_>, Error> {
@@ -145,35 +115,21 @@ struct KeyCapturingSink<'a> {
 }
 
 impl<'a> Sink for KeyCapturingSink<'a> {
-    fn null(&mut self, state: &DeserializerState) -> Result<(), Error> {
-        self.sink.null(state)
-    }
-
-    fn bool(&mut self, value: bool, state: &DeserializerState) -> Result<(), Error> {
-        self.sink.bool(value, state)
-    }
-
-    fn str(&mut self, value: &str, state: &DeserializerState) -> Result<(), Error> {
-        *self.captured_segment.borrow_mut() = Some(PathSegment::Key(value.to_string()));
-        self.sink.str(value, state)
-    }
-
-    fn bytes(&mut self, value: &[u8], state: &DeserializerState) -> Result<(), Error> {
-        self.sink.bytes(value, state)
-    }
-
-    fn u64(&mut self, value: u64, state: &DeserializerState) -> Result<(), Error> {
-        *self.captured_segment.borrow_mut() = Some(PathSegment::Index(value as usize));
-        self.sink.u64(value, state)
-    }
-
-    fn i64(&mut self, value: i64, state: &DeserializerState) -> Result<(), Error> {
-        *self.captured_segment.borrow_mut() = Some(PathSegment::Index(value as usize));
-        self.sink.i64(value, state)
-    }
-
-    fn f64(&mut self, value: f64, state: &DeserializerState) -> Result<(), Error> {
-        self.sink.f64(value, state)
+    fn atom(&mut self, atom: Atom, state: &DeserializerState) -> Result<(), Error> {
+        match atom {
+            Atom::Str(ref value) => {
+                *self.captured_segment.borrow_mut() = Some(PathSegment::Key(value.to_string()));
+            }
+            Atom::U64(value) => {
+                *self.captured_segment.borrow_mut() = Some(PathSegment::Index(value as usize));
+            }
+            Atom::I64(value) => {
+                *self.captured_segment.borrow_mut() = Some(PathSegment::Index(value as usize));
+            }
+            _ => {}
+        }
+        self.sink.atom(atom, state)?;
+        Ok(())
     }
 
     fn map(&mut self, state: &DeserializerState) -> Result<Box<dyn MapSink + '_>, Error> {

--- a/deser-path/src/de.rs
+++ b/deser-path/src/de.rs
@@ -116,18 +116,12 @@ struct KeyCapturingSink<'a> {
 
 impl<'a> Sink for KeyCapturingSink<'a> {
     fn atom(&mut self, atom: Atom, state: &DeserializerState) -> Result<(), Error> {
-        match atom {
-            Atom::Str(ref value) => {
-                *self.captured_segment.borrow_mut() = Some(PathSegment::Key(value.to_string()));
-            }
-            Atom::U64(value) => {
-                *self.captured_segment.borrow_mut() = Some(PathSegment::Index(value as usize));
-            }
-            Atom::I64(value) => {
-                *self.captured_segment.borrow_mut() = Some(PathSegment::Index(value as usize));
-            }
-            _ => {}
-        }
+        *self.captured_segment.borrow_mut() = match atom {
+            Atom::Str(ref value) => Some(PathSegment::Key(value.to_string())),
+            Atom::U64(value) => Some(PathSegment::Index(value as usize)),
+            Atom::I64(value) => Some(PathSegment::Index(value as usize)),
+            _ => None,
+        };
         self.sink.atom(atom, state)?;
         Ok(())
     }

--- a/deser-path/src/lib.rs
+++ b/deser-path/src/lib.rs
@@ -5,7 +5,7 @@
 //! ```rust
 //! use deser_path::{Path, PathSerializable};
 //! use deser::ser::{Serialize, SerializerState, Chunk};
-//! use deser::Error;
+//! use deser::{Atom, Error};
 //!
 //! struct MyInt(u32);
 //!
@@ -15,7 +15,7 @@
 //!         // any point request the current path from the state.
 //!         let path = state.get::<Path>();
 //!         println!("{:?}", path.segments());
-//!         Ok(Chunk::U64(self.0 as u64))
+//!         self.0.serialize(state)
 //!     }
 //! }
 //!

--- a/deser-path/src/ser.rs
+++ b/deser-path/src/ser.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use deser::ser::{
     Chunk, MapEmitter, SeqEmitter, Serialize, SerializeHandle, SerializerState, StructEmitter,
 };
-use deser::Error;
+use deser::{Atom, Error};
 
 use crate::{Path, PathSegment};
 
@@ -145,13 +145,13 @@ struct SegmentCollectingSerializable<'a> {
 impl<'a> Serialize for SegmentCollectingSerializable<'a> {
     fn serialize(&self, state: &SerializerState) -> Result<Chunk, Error> {
         match self.serializable.serialize(state)? {
-            Chunk::Str(key) => {
+            Chunk::Atom(Atom::Str(key)) => {
                 *self.segment.borrow_mut() = Some(PathSegment::Key(key.to_string()));
-                Ok(Chunk::Str(key))
+                Ok(Chunk::Atom(Atom::Str(key)))
             }
-            Chunk::U64(val) => {
+            Chunk::Atom(Atom::U64(val)) => {
                 *self.segment.borrow_mut() = Some(PathSegment::Index(val as usize));
-                Ok(Chunk::U64(val))
+                Ok(Chunk::Atom(Atom::U64(val)))
             }
             other => Ok(other),
         }

--- a/deser-path/tests/de.rs
+++ b/deser-path/tests/de.rs
@@ -37,10 +37,10 @@ fn test_path() {
         let sink = PathSink::wrap_ref(Deserialize::deserialize_into(&mut out));
         let mut driver = Driver::from_sink(SinkHandle::boxed(sink));
         driver.emit(Event::MapStart).unwrap();
-        driver.emit(Event::Atom(Atom::Str("foo".into()))).unwrap();
-        driver.emit(Event::Atom(Atom::Bool(true))).unwrap();
-        driver.emit(Event::Atom(Atom::Str("bar".into()))).unwrap();
-        driver.emit(Event::Atom(Atom::Bool(false))).unwrap();
+        driver.emit("foo").unwrap();
+        driver.emit(true).unwrap();
+        driver.emit("bar").unwrap();
+        driver.emit(false).unwrap();
         driver.emit(Event::MapEnd).unwrap();
     }
 

--- a/deser-path/tests/de.rs
+++ b/deser-path/tests/de.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use deser::de::{Deserialize, DeserializerState, Driver, Sink, SinkHandle};
-use deser::{Error, Event};
+use deser::{Atom, Error, Event};
 use deser_path::{Path, PathSink};
 
 #[derive(Debug, PartialEq, Eq)]
@@ -16,11 +16,16 @@ impl Deserialize for MyBool {
 }
 
 impl Sink for SlotWrapper<MyBool> {
-    fn bool(&mut self, value: bool, state: &DeserializerState) -> Result<(), Error> {
-        let path = state.get::<Path>();
-        assert_eq!(path.segments().len(), 1);
-        **self = Some(MyBool(value));
-        Ok(())
+    fn atom(&mut self, atom: Atom, state: &DeserializerState) -> Result<(), Error> {
+        match atom {
+            Atom::Bool(value) => {
+                let path = state.get::<Path>();
+                assert_eq!(path.segments().len(), 1);
+                **self = Some(MyBool(value));
+                Ok(())
+            }
+            other => Err(other.unexpected_error(&self.expecting())),
+        }
     }
 }
 
@@ -31,12 +36,12 @@ fn test_path() {
     {
         let sink = PathSink::wrap_ref(Deserialize::deserialize_into(&mut out));
         let mut driver = Driver::from_sink(SinkHandle::boxed(sink));
-        driver.emit(&Event::MapStart).unwrap();
-        driver.emit(&Event::Str("foo".into())).unwrap();
-        driver.emit(&Event::Bool(true)).unwrap();
-        driver.emit(&Event::Str("bar".into())).unwrap();
-        driver.emit(&Event::Bool(false)).unwrap();
-        driver.emit(&Event::MapEnd).unwrap();
+        driver.emit(Event::MapStart).unwrap();
+        driver.emit(Event::Atom(Atom::Str("foo".into()))).unwrap();
+        driver.emit(Event::Atom(Atom::Bool(true))).unwrap();
+        driver.emit(Event::Atom(Atom::Str("bar".into()))).unwrap();
+        driver.emit(Event::Atom(Atom::Bool(false))).unwrap();
+        driver.emit(Event::MapEnd).unwrap();
     }
 
     let map = out.unwrap();

--- a/deser-path/tests/ser.rs
+++ b/deser-path/tests/ser.rs
@@ -32,10 +32,10 @@ fn test_path() {
         events,
         vec![
             "MapStart|[]",
-            "Str(\"key\")|[]",
+            "Atom(Str(\"key\"))|[]",
             "SeqStart|[Key(\"key\")]",
-            "Bool(false)|[Key(\"key\"), Index(0)]",
-            "Bool(true)|[Key(\"key\"), Index(1)]",
+            "Atom(Bool(false))|[Key(\"key\"), Index(0)]",
+            "Atom(Bool(true))|[Key(\"key\"), Index(1)]",
             "SeqEnd|[Key(\"key\")]",
             "MapEnd|[]"
         ]

--- a/deser-path/tests/ser.rs
+++ b/deser-path/tests/ser.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use deser::ser::{for_each_event, Chunk, Serialize, SerializerState};
-use deser::Error;
+use deser::{Error, Atom};
 use deser_path::{Path, PathSerializable};
 
 struct MyBool(bool);
@@ -10,7 +10,7 @@ impl Serialize for MyBool {
     fn serialize(&self, state: &SerializerState) -> Result<Chunk, Error> {
         let path = state.get::<Path>();
         assert_eq!(path.segments().len(), 2);
-        Ok(Chunk::Bool(self.0))
+        Ok(Chunk::Atom(Atom::Bool(self.0)))
     }
 }
 

--- a/deser-path/tests/ser.rs
+++ b/deser-path/tests/ser.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use deser::ser::{for_each_event, Chunk, Serialize, SerializerState};
-use deser::{Error, Atom};
+use deser::{Atom, Error};
 use deser_path::{Path, PathSerializable};
 
 struct MyBool(bool);

--- a/deser/src/de/ignore.rs
+++ b/deser/src/de/ignore.rs
@@ -1,5 +1,6 @@
 use crate::de::{DeserializerState, MapSink, SeqSink, Sink, SinkHandle};
 use crate::error::Error;
+use crate::Atom;
 
 /// A [`Sink`] that ignores all values.
 ///
@@ -16,31 +17,7 @@ pub fn ignore() -> &'static mut dyn Sink {
 pub struct Ignore;
 
 impl Sink for Ignore {
-    fn null(&mut self, _state: &DeserializerState) -> Result<(), crate::Error> {
-        Ok(())
-    }
-
-    fn bool(&mut self, _value: bool, _state: &DeserializerState) -> Result<(), crate::Error> {
-        Ok(())
-    }
-
-    fn str(&mut self, _value: &str, _state: &DeserializerState) -> Result<(), crate::Error> {
-        Ok(())
-    }
-
-    fn bytes(&mut self, _value: &[u8], _state: &DeserializerState) -> Result<(), crate::Error> {
-        Ok(())
-    }
-
-    fn u64(&mut self, _value: u64, _state: &DeserializerState) -> Result<(), crate::Error> {
-        Ok(())
-    }
-
-    fn i64(&mut self, _value: i64, _state: &DeserializerState) -> Result<(), crate::Error> {
-        Ok(())
-    }
-
-    fn f64(&mut self, _value: f64, _state: &DeserializerState) -> Result<(), crate::Error> {
+    fn atom(&mut self, _atom: Atom, _state: &DeserializerState) -> Result<(), Error> {
         Ok(())
     }
 

--- a/deser/src/de/mod.rs
+++ b/deser/src/de/mod.rs
@@ -512,10 +512,10 @@ fn test_driver() {
     {
         let mut driver = Driver::new(&mut out);
         driver.emit(Event::MapStart).unwrap();
-        driver.emit(Event::Atom(Atom::I64(1))).unwrap();
-        driver.emit(Event::Atom(Atom::Str("Hello".into()))).unwrap();
-        driver.emit(Event::Atom(Atom::I64(2))).unwrap();
-        driver.emit(Event::Atom(Atom::Str("World".into()))).unwrap();
+        driver.emit(1u64).unwrap();
+        driver.emit("Hello").unwrap();
+        driver.emit(2u64).unwrap();
+        driver.emit("World").unwrap();
         driver.emit(Event::MapEnd).unwrap();
     }
 

--- a/deser/src/de/mod.rs
+++ b/deser/src/de/mod.rs
@@ -36,16 +36,17 @@
 //! ```rust
 //! use std::collections::BTreeMap;
 //! use deser::de::Driver;
-//! use deser::{Atom, Event};
+//! use deser::Event;
 //!
 //! let mut out = None::<BTreeMap<u32, String>>;
 //! {
 //!     let mut driver = Driver::new(&mut out);
+//!     // emit takes values that implement Into<Event>
 //!     driver.emit(Event::MapStart).unwrap();
-//!     driver.emit(Event::Atom(Atom::I64(1))).unwrap();
-//!     driver.emit(Event::Atom(Atom::Str("Hello".into()))).unwrap();
-//!     driver.emit(Event::Atom(Atom::I64(2))).unwrap();
-//!     driver.emit(Event::Atom(Atom::Str("World".into()))).unwrap();
+//!     driver.emit(1i64).unwrap();
+//!     driver.emit("Hello").unwrap();
+//!     driver.emit(2i64).unwrap();
+//!     driver.emit("World").unwrap();
 //!     driver.emit(Event::MapEnd).unwrap();
 //! }
 //!

--- a/deser/src/event.rs
+++ b/deser/src/event.rs
@@ -1,5 +1,100 @@
 use std::borrow::Cow;
 
+use crate::error::{Error, ErrorKind};
+
+/// An atom is a primitive value for serialization and deserialization.
+///
+/// Atoms are values that are sent directly to a serializer or deserializer.
+/// Examples for this are booleans or integers.  This is in contrast to
+/// compound values like maps, structs or sequences.
+#[derive(Debug, PartialEq, Clone)]
+pub enum Atom<'a> {
+    Null,
+    Bool(bool),
+    Str(Cow<'a, str>),
+    Bytes(Cow<'a, [u8]>),
+    U64(u64),
+    I64(i64),
+    F64(f64),
+}
+
+impl<'a> Atom<'a> {
+    /// Makes a static clone of the atom decoupling the lifetimes.
+    pub fn to_static(&self) -> Atom<'static> {
+        match *self {
+            Atom::Null => Atom::Null,
+            Atom::Bool(v) => Atom::Bool(v),
+            Atom::Str(ref v) => Atom::Str(Cow::Owned(v.to_string())),
+            Atom::Bytes(ref v) => Atom::Bytes(Cow::Owned(v.to_vec())),
+            Atom::U64(v) => Atom::U64(v),
+            Atom::I64(v) => Atom::I64(v),
+            Atom::F64(v) => Atom::F64(v),
+        }
+    }
+
+    /// Returns the human readable name of the atom.
+    pub fn name(&self) -> &str {
+        match *self {
+            Atom::Null => "null",
+            Atom::Bool(_) => "bool",
+            Atom::Str(_) => "string",
+            Atom::Bytes(_) => "bytes",
+            Atom::U64(_) => "unsigned integer",
+            Atom::I64(_) => "signed integer",
+            Atom::F64(_) => "float",
+        }
+    }
+
+    /// Creates an "unexpected" error.
+    pub fn unexpected_error(&self, expectation: &str) -> Error {
+        Error::new(
+            ErrorKind::Unexpected,
+            format!("unexpected {}, expected {}", self.name(), expectation),
+        )
+    }
+}
+
+macro_rules! impl_from {
+    ($ty:ty, $atom:ident) => {
+        impl From<$ty> for Event<'static> {
+            fn from(value: $ty) -> Self {
+                Event::Atom(Atom::$atom(value as _))
+            }
+        }
+    };
+}
+
+impl_from!(u64, U64);
+impl_from!(i64, I64);
+impl_from!(f64, F64);
+impl_from!(usize, U64);
+impl_from!(isize, I64);
+impl_from!(bool, Bool);
+
+impl From<()> for Event<'static> {
+    fn from(_: ()) -> Event<'static> {
+        Event::Atom(Atom::Null)
+    }
+}
+
+impl<'a> From<&'a str> for Event<'a> {
+    fn from(value: &'a str) -> Event<'a> {
+        Event::Atom(Atom::Str(Cow::Borrowed(value)))
+    }
+}
+
+impl From<String> for Event<'static> {
+    fn from(value: String) -> Event<'static> {
+        Event::Atom(Atom::Str(Cow::Owned(value)))
+    }
+}
+
+impl<'a> From<Atom<'a>> for Event<'a> {
+    fn from(atom: Atom<'a>) -> Self {
+        Event::Atom(atom)
+    }
+}
+
 /// An event represents an atomic serialization and deserialization event.
 ///
 /// ## Serialization
@@ -14,15 +109,9 @@ use std::borrow::Cow;
 ///
 /// During deserialization events are passed to a [`Driver`](crate::de::Driver)
 /// to drive the deserialization.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Event<'a> {
-    Null,
-    Bool(bool),
-    Str(Cow<'a, str>),
-    Bytes(Cow<'a, [u8]>),
-    U64(u64),
-    I64(i64),
-    F64(f64),
+    Atom(Atom<'a>),
     MapStart,
     MapEnd,
     SeqStart,
@@ -33,13 +122,7 @@ impl<'a> Event<'a> {
     /// Makes a static clone of the event decoupling the lifetimes.
     pub fn to_static(&self) -> Event<'static> {
         match *self {
-            Event::Null => Event::Null,
-            Event::Bool(v) => Event::Bool(v),
-            Event::Str(ref v) => Event::Str(Cow::Owned(v.to_string())),
-            Event::Bytes(ref v) => Event::Bytes(Cow::Owned(v.to_vec())),
-            Event::U64(v) => Event::U64(v),
-            Event::I64(v) => Event::I64(v),
-            Event::F64(v) => Event::F64(v),
+            Event::Atom(ref atom) => Event::Atom(atom.to_static()),
             Event::MapStart => Event::MapStart,
             Event::MapEnd => Event::MapEnd,
             Event::SeqStart => Event::SeqStart,

--- a/deser/src/event.rs
+++ b/deser/src/event.rs
@@ -46,6 +46,20 @@ impl<'a> Atom<'a> {
     }
 
     /// Creates an "unexpected" error.
+    ///
+    /// This is useful when implementing sinks that do not want to deal with an
+    /// atom of a specific type.  The default implementation of a
+    /// [`Sink`](crate::de::Sink) uses this method as follows:
+    ///
+    /// ```
+    /// # use deser::{Atom, Error, de::{DeserializerState, Sink}};
+    /// # struct MySink;
+    /// impl Sink for MySink {
+    ///     fn atom(&mut self, atom: Atom, _state: &DeserializerState) -> Result<(), Error> {
+    ///         Err(atom.unexpected_error(&self.expecting()))
+    ///     }
+    /// }
+    /// ```
     pub fn unexpected_error(&self, expectation: &str) -> Error {
         Error::new(
             ErrorKind::Unexpected,

--- a/deser/src/lib.rs
+++ b/deser/src/lib.rs
@@ -20,7 +20,7 @@ mod extensions;
 
 pub use self::descriptors::Descriptor;
 pub use self::error::{Error, ErrorKind};
-pub use self::event::Event;
+pub use self::event::{Atom, Event};
 
 #[doc(inline)]
 pub use self::{de::Deserialize, ser::Serialize};

--- a/deser/src/ser/chunk.rs
+++ b/deser/src/ser/chunk.rs
@@ -1,0 +1,59 @@
+use std::borrow::Cow;
+
+use crate::event::Atom;
+use crate::ser::{MapEmitter, SeqEmitter, StructEmitter};
+
+/// A chunk represents the minimum state necessary to serialize a value.
+///
+/// Chunks are of two types: atomic primitives and stateful emitters.
+/// For instance `Chunk::Bool(true)` is an atomic primitive.  It can be emitted
+/// to a serializer directly.  On the other hand a `Chunk::Map` contains a
+/// stateful emitter that keeps yielding values until it's done walking over
+/// the map.
+pub enum Chunk<'a> {
+    Atom(Atom<'a>),
+    Struct(Box<dyn StructEmitter + 'a>),
+    Map(Box<dyn MapEmitter + 'a>),
+    Seq(Box<dyn SeqEmitter + 'a>),
+}
+
+impl<'a> From<Atom<'a>> for Chunk<'a> {
+    fn from(atom: Atom<'a>) -> Self {
+        Chunk::Atom(atom)
+    }
+}
+
+macro_rules! impl_from {
+    ($ty:ty, $atom:ident) => {
+        impl From<$ty> for Chunk<'static> {
+            fn from(value: $ty) -> Self {
+                Chunk::Atom(Atom::$atom(value as _))
+            }
+        }
+    };
+}
+
+impl_from!(u64, U64);
+impl_from!(i64, I64);
+impl_from!(f64, F64);
+impl_from!(usize, U64);
+impl_from!(isize, I64);
+impl_from!(bool, Bool);
+
+impl From<()> for Chunk<'static> {
+    fn from(_: ()) -> Chunk<'static> {
+        Chunk::Atom(Atom::Null)
+    }
+}
+
+impl<'a> From<&'a str> for Chunk<'a> {
+    fn from(value: &'a str) -> Chunk<'a> {
+        Chunk::Atom(Atom::Str(Cow::Borrowed(value)))
+    }
+}
+
+impl From<String> for Chunk<'static> {
+    fn from(value: String) -> Chunk<'static> {
+        Chunk::Atom(Atom::Str(Cow::Owned(value)))
+    }
+}

--- a/deser/src/ser/impls.rs
+++ b/deser/src/ser/impls.rs
@@ -4,6 +4,7 @@ use std::hash::BuildHasher;
 
 use crate::descriptors::{Descriptor, NamedDescriptor, NumberDescriptor, UnorderedNamedDescriptor};
 use crate::error::Error;
+use crate::event::Atom;
 use crate::ser::{Chunk, MapEmitter, SeqEmitter, Serialize, SerializeHandle, SerializerState};
 
 impl Serialize for bool {
@@ -13,7 +14,7 @@ impl Serialize for bool {
     }
 
     fn serialize(&self, _state: &SerializerState) -> Result<Chunk, Error> {
-        Ok(Chunk::Bool(*self))
+        Ok(Chunk::Atom(Atom::Bool(*self)))
     }
 }
 
@@ -24,7 +25,7 @@ impl Serialize for () {
     }
 
     fn serialize(&self, _state: &SerializerState) -> Result<Chunk, Error> {
-        Ok(Chunk::Null)
+        Ok(Chunk::Atom(Atom::Null))
     }
 }
 
@@ -38,7 +39,7 @@ impl Serialize for u8 {
     }
 
     fn serialize(&self, _state: &SerializerState) -> Result<Chunk, Error> {
-        Ok(Chunk::U64(*self as u64))
+        Ok(Chunk::Atom(Atom::U64(*self as u64)))
     }
 
     fn __private_slice_as_bytes(val: &[u8]) -> Option<&[u8]> {
@@ -56,7 +57,7 @@ impl Serialize for u16 {
     }
 
     fn serialize(&self, _state: &SerializerState) -> Result<Chunk, Error> {
-        Ok(Chunk::U64(*self as u64))
+        Ok(Chunk::Atom(Atom::U64(*self as u64)))
     }
 }
 
@@ -70,7 +71,7 @@ impl Serialize for u32 {
     }
 
     fn serialize(&self, _state: &SerializerState) -> Result<Chunk, Error> {
-        Ok(Chunk::U64(*self as u64))
+        Ok(Chunk::Atom(Atom::U64(*self as u64)))
     }
 }
 
@@ -84,7 +85,7 @@ impl Serialize for u64 {
     }
 
     fn serialize(&self, _state: &SerializerState) -> Result<Chunk, Error> {
-        Ok(Chunk::U64(*self))
+        Ok(Chunk::Atom(Atom::U64(*self)))
     }
 }
 
@@ -98,7 +99,7 @@ impl Serialize for i8 {
     }
 
     fn serialize(&self, _state: &SerializerState) -> Result<Chunk, Error> {
-        Ok(Chunk::I64(*self as i64))
+        Ok(Chunk::Atom(Atom::I64(*self as i64)))
     }
 }
 
@@ -112,7 +113,7 @@ impl Serialize for i16 {
     }
 
     fn serialize(&self, _state: &SerializerState) -> Result<Chunk, Error> {
-        Ok(Chunk::I64(*self as i64))
+        Ok(Chunk::Atom(Atom::I64(*self as i64)))
     }
 }
 
@@ -126,7 +127,7 @@ impl Serialize for i32 {
     }
 
     fn serialize(&self, _state: &SerializerState) -> Result<Chunk, Error> {
-        Ok(Chunk::I64(*self as i64))
+        Ok(Chunk::Atom(Atom::I64(*self as i64)))
     }
 }
 
@@ -140,7 +141,7 @@ impl Serialize for i64 {
     }
 
     fn serialize(&self, _state: &SerializerState) -> Result<Chunk, Error> {
-        Ok(Chunk::I64(*self))
+        Ok(Chunk::Atom(Atom::I64(*self)))
     }
 }
 
@@ -154,7 +155,7 @@ impl Serialize for isize {
     }
 
     fn serialize(&self, _state: &SerializerState) -> Result<Chunk, Error> {
-        Ok(Chunk::I64(*self as i64))
+        Ok(Chunk::Atom(Atom::I64(*self as i64)))
     }
 }
 
@@ -168,7 +169,7 @@ impl Serialize for usize {
     }
 
     fn serialize(&self, _state: &SerializerState) -> Result<Chunk, Error> {
-        Ok(Chunk::U64(*self as u64))
+        Ok(Chunk::Atom(Atom::U64(*self as u64)))
     }
 }
 
@@ -182,7 +183,7 @@ impl Serialize for f32 {
     }
 
     fn serialize(&self, _state: &SerializerState) -> Result<Chunk, Error> {
-        Ok(Chunk::F64(*self as f64))
+        Ok(Chunk::Atom(Atom::F64(*self as f64)))
     }
 }
 
@@ -196,7 +197,7 @@ impl Serialize for f64 {
     }
 
     fn serialize(&self, _state: &SerializerState) -> Result<Chunk, Error> {
-        Ok(Chunk::F64(*self))
+        Ok(Chunk::Atom(Atom::F64(*self)))
     }
 }
 
@@ -207,7 +208,7 @@ impl Serialize for String {
     }
 
     fn serialize(&self, _state: &SerializerState) -> Result<Chunk, Error> {
-        Ok(Chunk::Str(self.as_str().into()))
+        Ok(Chunk::Atom(Atom::Str(self.as_str().into())))
     }
 }
 
@@ -218,7 +219,7 @@ impl<'a> Serialize for &'a str {
     }
 
     fn serialize(&self, _state: &SerializerState) -> Result<Chunk, Error> {
-        Ok(Chunk::Str((*self).into()))
+        Ok(Chunk::Atom(Atom::Str((*self).into())))
     }
 }
 
@@ -229,7 +230,7 @@ impl<'a> Serialize for Cow<'a, str> {
     }
 
     fn serialize(&self, _state: &SerializerState) -> Result<Chunk, Error> {
-        Ok(Chunk::Str(Cow::Borrowed(self)))
+        Ok(Chunk::Atom(Atom::Str(Cow::Borrowed(self))))
     }
 }
 
@@ -249,7 +250,7 @@ where
 
     fn serialize(&self, _state: &SerializerState) -> Result<Chunk, Error> {
         if let Some(bytes) = T::__private_slice_as_bytes(&self[..]) {
-            Ok(Chunk::Bytes(Cow::Borrowed(bytes)))
+            Ok(Chunk::Atom(Atom::Bytes(Cow::Borrowed(bytes))))
         } else {
             Ok(Chunk::Seq(Box::new(SliceEmitter((&self[..]).iter()))))
         }
@@ -272,7 +273,7 @@ where
 
     fn serialize(&self, _state: &SerializerState) -> Result<Chunk, Error> {
         if let Some(bytes) = T::__private_slice_as_bytes(self) {
-            Ok(Chunk::Bytes(Cow::Borrowed(bytes)))
+            Ok(Chunk::Atom(Atom::Bytes(Cow::Borrowed(bytes))))
         } else {
             Ok(Chunk::Seq(Box::new(SliceEmitter(self.iter()))))
         }
@@ -418,7 +419,7 @@ where
     fn serialize(&self, state: &SerializerState) -> Result<Chunk, Error> {
         match self {
             Some(value) => value.serialize(state),
-            None => Ok(Chunk::Null),
+            None => Ok(Chunk::Atom(Atom::Null)),
         }
     }
 }

--- a/deser/tests/test_custom_map.rs
+++ b/deser/tests/test_custom_map.rs
@@ -53,12 +53,12 @@ fn test_as_string_map() {
         events,
         vec![
             "MapStart",
-            "Str(\"0\")",
-            "Bool(true)",
-            "Str(\"1\")",
-            "Bool(true)",
-            "Str(\"2\")",
-            "Bool(false)",
+            "Atom(Str(\"0\"))",
+            "Atom(Bool(true))",
+            "Atom(Str(\"1\"))",
+            "Atom(Bool(true))",
+            "Atom(Str(\"2\"))",
+            "Atom(Bool(false))",
             "MapEnd"
         ]
     );

--- a/deser/tests/test_de.rs
+++ b/deser/tests/test_de.rs
@@ -1,19 +1,19 @@
 use deser::de::Driver;
-use deser::Event;
+use deser::{Atom, Event};
 
 #[test]
 fn test_optional() {
     let mut out = None::<Option<usize>>;
     {
         let mut driver = Driver::new(&mut out);
-        driver.emit(&Event::U64(42)).unwrap();
+        driver.emit(Event::Atom(Atom::U64(42))).unwrap();
     }
     assert_eq!(out, Some(Some(42)));
 
     let mut out = None::<Option<usize>>;
     {
         let mut driver = Driver::new(&mut out);
-        driver.emit(&Event::Null).unwrap();
+        driver.emit(Event::Atom(Atom::Null)).unwrap();
     }
     assert_eq!(out, Some(None));
 }

--- a/deser/tests/test_ser.rs
+++ b/deser/tests/test_ser.rs
@@ -1,5 +1,5 @@
 use deser::ser::for_each_event;
-use deser::{Event, Serialize};
+use deser::{Atom, Event, Serialize};
 
 fn capture_events(s: &dyn Serialize) -> Vec<Event<'static>> {
     let mut events = Vec::new();
@@ -14,8 +14,8 @@ fn capture_events(s: &dyn Serialize) -> Vec<Event<'static>> {
 #[test]
 fn test_optional() {
     let events = capture_events(&None::<usize>);
-    assert_eq!(events, vec![Event::Null]);
+    assert_eq!(events, vec![Event::Atom(Atom::Null)]);
 
     let events = capture_events(&Some(42usize));
-    assert_eq!(events, vec![Event::U64(42)]);
+    assert_eq!(events, vec![Event::Atom(Atom::U64(42))]);
 }


### PR DESCRIPTION
This change introduces a new `Atom` type that holds primitives. There is now a default `atom` method on the sinks that receive these atoms rather than individual methods for each primitive type. This also changes the `Event` type so that atoms are directly placed on it. Additionally instead of passing event references, they are now passed by value.

Fixes #7