### PR TITLE
Remove MapSink and SeqSink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to deser are documented here.
 ## 0.6.0
 
 - Made `Atom` non exhaustive and added `unexpected_atom` to `Deserialize`.
+- Removed `MapSink` and `SeqSink`.  The functionality of these is now
+  directly on the `Sink`.
 
 ## 0.5.0
 

--- a/deser/src/de/ignore.rs
+++ b/deser/src/de/ignore.rs
@@ -1,4 +1,4 @@
-use crate::de::{DeserializerState, MapSink, SeqSink, Sink, SinkHandle};
+use crate::de::{DeserializerState, Sink, SinkHandle};
 use crate::error::Error;
 use crate::Atom;
 
@@ -9,35 +9,19 @@ impl Sink for Ignore {
         Ok(())
     }
 
-    fn map(&mut self, _state: &DeserializerState) -> Result<Box<dyn MapSink + '_>, crate::Error> {
-        Ok(Box::new(Ignore))
-    }
-
-    fn seq(&mut self, _state: &DeserializerState) -> Result<Box<dyn SeqSink + '_>, crate::Error> {
-        Ok(Box::new(Ignore))
-    }
-}
-
-impl MapSink for Ignore {
-    fn key(&mut self) -> Result<SinkHandle, Error> {
-        Ok(SinkHandle::null())
-    }
-
-    fn value(&mut self) -> Result<SinkHandle, Error> {
-        Ok(SinkHandle::null())
-    }
-
-    fn finish(&mut self, _state: &DeserializerState) -> Result<(), Error> {
+    fn map(&mut self, _state: &DeserializerState) -> Result<(), Error> {
         Ok(())
     }
-}
 
-impl SeqSink for Ignore {
-    fn item(&mut self) -> Result<SinkHandle, Error> {
+    fn seq(&mut self, _state: &DeserializerState) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn next_key(&mut self) -> Result<SinkHandle, Error> {
         Ok(SinkHandle::null())
     }
 
-    fn finish(&mut self, _state: &DeserializerState) -> Result<(), Error> {
-        Ok(())
+    fn next_value(&mut self) -> Result<SinkHandle, Error> {
+        Ok(SinkHandle::null())
     }
 }

--- a/deser/src/de/impls.rs
+++ b/deser/src/de/impls.rs
@@ -440,16 +440,16 @@ impl<'a> Sink for NullIgnoringSink<'a> {
         self.sink.map(state)
     }
 
+    fn seq(&mut self, state: &DeserializerState) -> Result<(), Error> {
+        self.sink.seq(state)
+    }
+
     fn next_key(&mut self) -> Result<SinkHandle, Error> {
         self.sink.next_key()
     }
 
     fn next_value(&mut self) -> Result<SinkHandle, Error> {
         self.sink.next_value()
-    }
-
-    fn seq(&mut self, state: &DeserializerState) -> Result<(), Error> {
-        self.sink.seq(state)
     }
 
     fn descriptor(&self) -> &dyn Descriptor {

--- a/deser/src/de/impls.rs
+++ b/deser/src/de/impls.rs
@@ -4,7 +4,7 @@ use std::hash::BuildHasher;
 use std::hash::Hash;
 use std::mem::{take, MaybeUninit};
 
-use crate::de::{Deserialize, DeserializerState, MapSink, SeqSink, Sink, SinkHandle};
+use crate::de::{Deserialize, DeserializerState, Sink, SinkHandle};
 use crate::descriptors::{Descriptor, NamedDescriptor, UnorderedNamedDescriptor};
 use crate::error::{Error, ErrorKind};
 use crate::event::Atom;
@@ -204,63 +204,84 @@ deserialize!(f32);
 float_sink!(f64);
 deserialize!(f64);
 
-impl<T: Deserialize> Sink for SlotWrapper<Vec<T>> {
-    fn expecting(&self) -> Cow<'_, str> {
-        if unsafe { T::__private_is_bytes() } {
-            "bytes".into()
-        } else {
-            "vec".into()
-        }
-    }
-
-    fn atom(&mut self, atom: Atom, state: &DeserializerState) -> Result<(), Error> {
-        match atom {
-            Atom::Bytes(value) => unsafe {
-                if T::__private_is_bytes() {
-                    **self = Some(std::mem::transmute(value.into_owned()));
-                    Ok(())
-                } else {
-                    Err(Error::new(
-                        ErrorKind::Unexpected,
-                        format!("unexpected bytes, expected {}", self.expecting()),
-                    ))
-                }
-            },
-            other => self.unexpected_atom(other, state),
-        }
-    }
-
-    fn seq(&mut self, _state: &DeserializerState) -> Result<Box<dyn SeqSink + '_>, Error> {
-        Ok(Box::new(VecSink {
-            slot: self,
-            vec: Vec::new(),
-            element: None,
-        }))
-    }
-}
-
 impl<T: Deserialize> Deserialize for Vec<T> {
     fn deserialize_into(out: &mut Option<Self>) -> SinkHandle {
-        SlotWrapper::make_handle(out)
-    }
-}
+        struct VecSink<'a, T> {
+            slot: &'a mut Option<Vec<T>>,
+            vec: Vec<T>,
+            element: Option<T>,
+            is_seq: bool,
+        }
 
-impl<K, V> Sink for SlotWrapper<BTreeMap<K, V>>
-where
-    K: Ord + Deserialize,
-    V: Deserialize,
-{
-    fn expecting(&self) -> Cow<'_, str> {
-        "map".into()
-    }
+        impl<'a, T: 'a> VecSink<'a, T> {
+            fn flush(&mut self) {
+                if let Some(element) = self.element.take() {
+                    self.vec.push(element);
+                }
+            }
+        }
 
-    fn map(&mut self, _state: &DeserializerState) -> Result<Box<dyn super::MapSink + '_>, Error> {
-        Ok(Box::new(BTreeMapSink {
-            slot: self,
-            map: BTreeMap::new(),
-            key: None,
-            value: None,
-        }))
+        impl<'a, T: Deserialize> Sink for VecSink<'a, T> {
+            fn descriptor(&self) -> &dyn Descriptor {
+                static SLICE_DESCRIPTOR: NamedDescriptor = NamedDescriptor { name: "Vec" };
+                static BYTES_DESCRIPTOR: NamedDescriptor = NamedDescriptor { name: "ByteVec" };
+                if unsafe { T::__private_is_bytes() } {
+                    &BYTES_DESCRIPTOR
+                } else {
+                    &SLICE_DESCRIPTOR
+                }
+            }
+
+            fn expecting(&self) -> Cow<'_, str> {
+                if unsafe { T::__private_is_bytes() } {
+                    "bytes".into()
+                } else {
+                    "vec".into()
+                }
+            }
+
+            fn atom(&mut self, atom: Atom, state: &DeserializerState) -> Result<(), Error> {
+                match atom {
+                    Atom::Bytes(value) => unsafe {
+                        if T::__private_is_bytes() {
+                            *self.slot = Some(std::mem::transmute(value.into_owned()));
+                            Ok(())
+                        } else {
+                            Err(Error::new(
+                                ErrorKind::Unexpected,
+                                format!("unexpected bytes, expected {}", self.expecting()),
+                            ))
+                        }
+                    },
+                    other => self.unexpected_atom(other, state),
+                }
+            }
+
+            fn seq(&mut self, _state: &DeserializerState) -> Result<(), Error> {
+                self.is_seq = true;
+                Ok(())
+            }
+
+            fn next_value(&mut self) -> Result<SinkHandle, Error> {
+                self.flush();
+                Ok(Deserialize::deserialize_into(&mut self.element))
+            }
+
+            fn finish(&mut self, _state: &DeserializerState) -> Result<(), Error> {
+                if self.is_seq {
+                    self.flush();
+                    *self.slot = Some(take(&mut self.vec));
+                }
+                Ok(())
+            }
+        }
+
+        SinkHandle::boxed(VecSink {
+            slot: out,
+            vec: Vec::new(),
+            element: None,
+            is_seq: false,
+        })
     }
 }
 
@@ -270,71 +291,61 @@ where
     V: Deserialize,
 {
     fn deserialize_into(out: &mut Option<Self>) -> SinkHandle {
-        SlotWrapper::make_handle(out)
-    }
-}
-
-struct BTreeMapSink<'a, K: 'a, V: 'a> {
-    slot: &'a mut Option<BTreeMap<K, V>>,
-    map: BTreeMap<K, V>,
-    key: Option<K>,
-    value: Option<V>,
-}
-
-impl<'a, K, V> BTreeMapSink<'a, K, V>
-where
-    K: Ord,
-{
-    fn flush(&mut self) {
-        if let (Some(key), Some(value)) = (self.key.take(), self.value.take()) {
-            self.map.insert(key, value);
+        struct MapSink<'a, K: 'a, V: 'a> {
+            slot: &'a mut Option<BTreeMap<K, V>>,
+            map: BTreeMap<K, V>,
+            key: Option<K>,
+            value: Option<V>,
         }
-    }
-}
 
-impl<'a, K, V> MapSink for BTreeMapSink<'a, K, V>
-where
-    K: Ord + Deserialize,
-    V: Deserialize,
-{
-    fn descriptor(&self) -> &dyn Descriptor {
-        static DESCRIPTOR: NamedDescriptor = NamedDescriptor { name: "BTreeMap" };
-        &DESCRIPTOR
-    }
+        impl<'a, K, V> MapSink<'a, K, V>
+        where
+            K: Ord,
+        {
+            fn flush(&mut self) {
+                if let (Some(key), Some(value)) = (self.key.take(), self.value.take()) {
+                    self.map.insert(key, value);
+                }
+            }
+        }
 
-    fn key(&mut self) -> Result<SinkHandle, Error> {
-        self.flush();
-        Ok(Deserialize::deserialize_into(&mut self.key))
-    }
+        impl<'a, K, V> Sink for MapSink<'a, K, V>
+        where
+            K: Ord + Deserialize,
+            V: Deserialize,
+        {
+            fn descriptor(&self) -> &dyn Descriptor {
+                static DESCRIPTOR: UnorderedNamedDescriptor =
+                    UnorderedNamedDescriptor { name: "map" };
+                &DESCRIPTOR
+            }
 
-    fn value(&mut self) -> Result<SinkHandle, Error> {
-        Ok(Deserialize::deserialize_into(&mut self.value))
-    }
+            fn map(&mut self, _state: &DeserializerState) -> Result<(), Error> {
+                Ok(())
+            }
 
-    fn finish(&mut self, _state: &DeserializerState) -> Result<(), Error> {
-        self.flush();
-        *self.slot = Some(take(&mut self.map));
-        Ok(())
-    }
-}
+            fn next_key(&mut self) -> Result<SinkHandle, Error> {
+                self.flush();
+                Ok(Deserialize::deserialize_into(&mut self.key))
+            }
 
-impl<K, V, H> Sink for SlotWrapper<HashMap<K, V, H>>
-where
-    K: Hash + Eq + Deserialize,
-    V: Deserialize,
-    H: BuildHasher + Default,
-{
-    fn expecting(&self) -> Cow<'_, str> {
-        "map".into()
-    }
+            fn next_value(&mut self) -> Result<SinkHandle, Error> {
+                Ok(Deserialize::deserialize_into(&mut self.value))
+            }
 
-    fn map(&mut self, _state: &DeserializerState) -> Result<Box<dyn super::MapSink + '_>, Error> {
-        Ok(Box::new(HashMapSink {
-            slot: self,
-            map: HashMap::default(),
+            fn finish(&mut self, _state: &DeserializerState) -> Result<(), Error> {
+                self.flush();
+                *self.slot = Some(take(&mut self.map));
+                Ok(())
+            }
+        }
+
+        SinkHandle::boxed(MapSink {
+            slot: out,
+            map: BTreeMap::new(),
             key: None,
             value: None,
-        }))
+        })
     }
 }
 
@@ -345,90 +356,59 @@ where
     H: BuildHasher + Default,
 {
     fn deserialize_into(out: &mut Option<Self>) -> SinkHandle {
-        SlotWrapper::make_handle(out)
-    }
-}
-
-struct HashMapSink<'a, K: 'a, V: 'a, H> {
-    slot: &'a mut Option<HashMap<K, V, H>>,
-    map: HashMap<K, V, H>,
-    key: Option<K>,
-    value: Option<V>,
-}
-
-impl<'a, K, V, H> HashMapSink<'a, K, V, H>
-where
-    K: Hash + Eq,
-    H: BuildHasher,
-{
-    fn flush(&mut self) {
-        if let (Some(key), Some(value)) = (self.key.take(), self.value.take()) {
-            self.map.insert(key, value);
+        struct MapSink<'a, K: 'a, V: 'a, H> {
+            slot: &'a mut Option<HashMap<K, V, H>>,
+            map: HashMap<K, V, H>,
+            key: Option<K>,
+            value: Option<V>,
         }
-    }
-}
 
-impl<'a, K, V, H> MapSink for HashMapSink<'a, K, V, H>
-where
-    K: Hash + Eq + Deserialize,
-    V: Deserialize,
-    H: BuildHasher + Default,
-{
-    fn descriptor(&self) -> &dyn Descriptor {
-        static DESCRIPTOR: UnorderedNamedDescriptor = UnorderedNamedDescriptor { name: "HashMap" };
-        &DESCRIPTOR
-    }
-
-    fn key(&mut self) -> Result<SinkHandle, Error> {
-        self.flush();
-        Ok(Deserialize::deserialize_into(&mut self.key))
-    }
-
-    fn value(&mut self) -> Result<SinkHandle, Error> {
-        Ok(Deserialize::deserialize_into(&mut self.value))
-    }
-
-    fn finish(&mut self, _state: &DeserializerState) -> Result<(), Error> {
-        self.flush();
-        *self.slot = Some(take(&mut self.map));
-        Ok(())
-    }
-}
-
-struct VecSink<'a, T: 'a> {
-    slot: &'a mut Option<Vec<T>>,
-    vec: Vec<T>,
-    element: Option<T>,
-}
-
-impl<'a, T: 'a> VecSink<'a, T> {
-    fn flush(&mut self) {
-        if let Some(element) = self.element.take() {
-            self.vec.push(element);
+        impl<'a, K, V, H> MapSink<'a, K, V, H>
+        where
+            K: Hash + Eq,
+            H: BuildHasher,
+        {
+            fn flush(&mut self) {
+                if let (Some(key), Some(value)) = (self.key.take(), self.value.take()) {
+                    self.map.insert(key, value);
+                }
+            }
         }
-    }
-}
 
-impl<'a, T: Deserialize> SeqSink for VecSink<'a, T> {
-    fn descriptor(&self) -> &dyn Descriptor {
-        static SLICE_DESCRIPTOR: NamedDescriptor = NamedDescriptor { name: "Vec" };
-        static BYTES_DESCRIPTOR: NamedDescriptor = NamedDescriptor { name: "ByteVec" };
-        if unsafe { T::__private_is_bytes() } {
-            &BYTES_DESCRIPTOR
-        } else {
-            &SLICE_DESCRIPTOR
+        impl<'a, K, V, H> Sink for MapSink<'a, K, V, H>
+        where
+            K: Hash + Eq + Deserialize,
+            V: Deserialize,
+            H: BuildHasher + Default,
+        {
+            fn descriptor(&self) -> &dyn Descriptor {
+                static DESCRIPTOR: UnorderedNamedDescriptor =
+                    UnorderedNamedDescriptor { name: "map" };
+                &DESCRIPTOR
+            }
+
+            fn next_key(&mut self) -> Result<SinkHandle, Error> {
+                self.flush();
+                Ok(Deserialize::deserialize_into(&mut self.key))
+            }
+
+            fn next_value(&mut self) -> Result<SinkHandle, Error> {
+                Ok(Deserialize::deserialize_into(&mut self.value))
+            }
+
+            fn finish(&mut self, _state: &DeserializerState) -> Result<(), Error> {
+                self.flush();
+                *self.slot = Some(take(&mut self.map));
+                Ok(())
+            }
         }
-    }
 
-    fn item(&mut self) -> Result<SinkHandle, Error> {
-        self.flush();
-        Ok(Deserialize::deserialize_into(&mut self.element))
-    }
-
-    fn finish(&mut self, _state: &DeserializerState) -> Result<(), Error> {
-        self.flush();
-        *self.slot = Some(take(&mut self.vec));
-        Ok(())
+        SinkHandle::boxed(MapSink {
+            slot: out,
+            map: HashMap::default(),
+            key: None,
+            value: None,
+        })
     }
 }
 
@@ -456,12 +436,24 @@ impl<'a> Sink for NullIgnoringSink<'a> {
         }
     }
 
-    fn map(&mut self, state: &DeserializerState) -> Result<Box<dyn MapSink + '_>, Error> {
+    fn map(&mut self, state: &DeserializerState) -> Result<(), Error> {
         self.sink.map(state)
     }
 
-    fn seq(&mut self, state: &DeserializerState) -> Result<Box<dyn SeqSink + '_>, Error> {
+    fn next_key(&mut self) -> Result<SinkHandle, Error> {
+        self.sink.next_key()
+    }
+
+    fn next_value(&mut self) -> Result<SinkHandle, Error> {
+        self.sink.next_value()
+    }
+
+    fn seq(&mut self, state: &DeserializerState) -> Result<(), Error> {
         self.sink.seq(state)
+    }
+
+    fn descriptor(&self) -> &dyn Descriptor {
+        self.sink.descriptor()
     }
 
     fn expecting(&self) -> Cow<'_, str> {
@@ -474,13 +466,8 @@ macro_rules! deserialize_for_tuple {
     ($($name:ident,)+) => (
         impl<$($name: Deserialize),*> Deserialize for ($($name,)*) {
             fn deserialize_into(out: &mut Option<Self>) -> SinkHandle {
-                SlotWrapper::make_handle(out)
-            }
-        }
+                #![allow(non_snake_case)]
 
-        impl<$($name: Deserialize),*> Sink for SlotWrapper<($($name,)*)> {
-            #[allow(non_snake_case)]
-            fn seq(&mut self, _state: &DeserializerState) -> Result<Box<dyn SeqSink + '_>, Error> {
                 struct TupleSink<'a, $($name,)*> {
                     slot: &'a mut Option<($($name,)*)>,
                     index: usize,
@@ -489,8 +476,16 @@ macro_rules! deserialize_for_tuple {
                     )*
                 }
 
-                impl<'a, $($name: Deserialize,)*> SeqSink for TupleSink<'a, $($name,)*> {
-                    fn item(&mut self) -> Result<SinkHandle, Error> {
+                impl<'a, $($name: Deserialize,)*> Sink for TupleSink<'a, $($name,)*> {
+                    fn expecting(&self) -> Cow<'_, str> {
+                        "tuple".into()
+                    }
+
+                    fn seq(&mut self, _state: &DeserializerState) -> Result<(), Error> {
+                        Ok(())
+                    }
+
+                    fn next_value(&mut self) -> Result<SinkHandle, Error> {
                         let __index = self.index;
                         self.index += 1;
                         let mut __counter = 0;
@@ -513,17 +508,13 @@ macro_rules! deserialize_for_tuple {
                     }
                 }
 
-                Ok(Box::new(TupleSink {
-                    slot: self,
+                SinkHandle::boxed(TupleSink {
+                    slot: out,
                     index: 0,
                     $(
                         $name: None,
                     )*
-                }))
-            }
-
-            fn expecting(&self) -> Cow<'_, str> {
-                "tuple".into()
+                })
             }
         }
 
@@ -540,7 +531,35 @@ deserialize_for_tuple! { T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, }
 impl<T: Deserialize, const N: usize> Deserialize for [T; N] {
     fn deserialize_into(out: &mut Option<Self>) -> SinkHandle {
         struct ArraySink<'a, T, const N: usize> {
-            out: &'a mut Option<[T; N]>,
+            slot: &'a mut Option<[T; N]>,
+            buffer: Option<[MaybeUninit<T>; N]>,
+            element: Option<T>,
+            index: usize,
+            is_seq: bool,
+        }
+
+        impl<'a, T, const N: usize> ArraySink<'a, T, N> {
+            unsafe fn flush(&mut self) {
+                if let Some(element) = self.element.take() {
+                    let buffer = self.buffer.as_mut().unwrap();
+                    buffer[self.index].write(element);
+                    self.index += 1;
+                }
+            }
+        }
+
+        impl<'a, T, const N: usize> Drop for ArraySink<'a, T, N> {
+            fn drop(&mut self) {
+                if std::mem::needs_drop::<T>() {
+                    if let Some(arr) = &mut self.buffer {
+                        for elem in &mut arr[0..self.index] {
+                            unsafe {
+                                std::ptr::drop_in_place(elem.as_mut_ptr());
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         impl<'a, T: Deserialize + 'a, const N: usize> Sink for ArraySink<'a, T, N> {
@@ -553,7 +572,7 @@ impl<T: Deserialize, const N: usize> Deserialize for [T; N] {
                     Atom::Bytes(value) => {
                         if unsafe { T::__private_is_bytes() } {
                             if value.len() == N {
-                                *self.out = Some(unsafe {
+                                *self.slot = Some(unsafe {
                                     let mut rv = MaybeUninit::<[T; N]>::uninit();
                                     std::ptr::copy_nonoverlapping(
                                         value.as_ptr() as *const T,
@@ -580,49 +599,12 @@ impl<T: Deserialize, const N: usize> Deserialize for [T; N] {
                 }
             }
 
-            fn seq(&mut self, _state: &DeserializerState) -> Result<Box<dyn SeqSink + '_>, Error> {
-                Ok(Box::new(ArraySeqSink {
-                    slot: self.out,
-                    buffer: Some(unsafe { MaybeUninit::uninit().assume_init() }),
-                    element: None,
-                    index: 0,
-                }))
+            fn seq(&mut self, _state: &DeserializerState) -> Result<(), Error> {
+                self.is_seq = true;
+                Ok(())
             }
-        }
 
-        struct ArraySeqSink<'a, T, const N: usize> {
-            slot: &'a mut Option<[T; N]>,
-            buffer: Option<[MaybeUninit<T>; N]>,
-            element: Option<T>,
-            index: usize,
-        }
-
-        impl<'a, T, const N: usize> ArraySeqSink<'a, T, N> {
-            unsafe fn flush(&mut self) {
-                if let Some(element) = self.element.take() {
-                    let buffer = self.buffer.as_mut().unwrap();
-                    buffer[self.index].write(element);
-                    self.index += 1;
-                }
-            }
-        }
-
-        impl<'a, T, const N: usize> Drop for ArraySeqSink<'a, T, N> {
-            fn drop(&mut self) {
-                if std::mem::needs_drop::<T>() {
-                    if let Some(arr) = &mut self.buffer {
-                        for elem in &mut arr[0..self.index] {
-                            unsafe {
-                                std::ptr::drop_in_place(elem.as_mut_ptr());
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        impl<'a, T: Deserialize, const N: usize> SeqSink for ArraySeqSink<'a, T, N> {
-            fn item(&mut self) -> Result<SinkHandle, Error> {
+            fn next_value(&mut self) -> Result<SinkHandle, Error> {
                 unsafe {
                     self.flush();
                 }
@@ -637,6 +619,9 @@ impl<T: Deserialize, const N: usize> Deserialize for [T; N] {
             }
 
             fn finish(&mut self, _state: &DeserializerState) -> Result<(), Error> {
+                if !self.is_seq {
+                    return Ok(());
+                }
                 unsafe {
                     self.flush();
                 }
@@ -654,6 +639,12 @@ impl<T: Deserialize, const N: usize> Deserialize for [T; N] {
             }
         }
 
-        SinkHandle::boxed(ArraySink { out })
+        SinkHandle::boxed(ArraySink {
+            slot: out,
+            buffer: Some(unsafe { MaybeUninit::uninit().assume_init() }),
+            element: None,
+            index: 0,
+            is_seq: false,
+        })
     }
 }

--- a/deser/src/de/mod.rs
+++ b/deser/src/de/mod.rs
@@ -300,13 +300,9 @@ pub trait Sink {
     }
 
     /// Implements a default fallback handling for atoms.
-    fn unexpected_atom(&mut self, atom: Atom, _state: &DeserializerState) -> Result<(), Error> {
+    fn unexpected_atom(&mut self, atom: Atom, state: &DeserializerState) -> Result<(), Error> {
+        let _ = state;
         Err(atom.unexpected_error(&self.expecting()))
-    }
-
-    /// Utility method to return an expectation message that is used in error messages.
-    fn expecting(&self) -> Cow<'_, str> {
-        "compatible type".into()
     }
 
     /// Begins the deserialization of a map.
@@ -316,7 +312,8 @@ pub trait Sink {
     /// called alternatingly.  The map is ended by [`finish`](Self::finish).
     ///
     /// The default implementation returns an error.
-    fn map(&mut self, _state: &DeserializerState) -> Result<(), Error> {
+    fn map(&mut self, state: &DeserializerState) -> Result<(), Error> {
+        let _ = state;
         Err(Error::new(
             ErrorKind::Unexpected,
             format!("unexpected map, expected {}", self.expecting()),
@@ -330,7 +327,8 @@ pub trait Sink {
     /// The sequence is ended by [`finish`](Self::finish).
     ///
     /// The default implementation returns an error.
-    fn seq(&mut self, _state: &DeserializerState) -> Result<(), Error> {
+    fn seq(&mut self, state: &DeserializerState) -> Result<(), Error> {
+        let _ = state;
         Err(Error::new(
             ErrorKind::Unexpected,
             format!("unexpected sequence, expected {}", self.expecting()),
@@ -347,16 +345,24 @@ pub trait Sink {
         Ok(SinkHandle::null())
     }
 
+    /// Called after [`atom`](Self::atom), [`map`](Self::map) or [`seq](Self::seq).
+    ///
+    /// The default implementation does nothing.
+    fn finish(&mut self, state: &DeserializerState) -> Result<(), Error> {
+        let _ = state;
+        Ok(())
+    }
+
     /// Returns a descriptor for this type.
     fn descriptor(&self) -> &dyn Descriptor {
         &NullDescriptor
     }
 
-    /// Called after [`atom`](Self::atom), [`map`](Self::map) or [`seq](Self::seq).
+    /// Utility method to return an expectation message that is used in error messages.
     ///
-    /// The default implementation does nothing.
-    fn finish(&mut self, _state: &DeserializerState) -> Result<(), Error> {
-        Ok(())
+    /// The default implementation returns the type name of the descriptor if available.
+    fn expecting(&self) -> Cow<'_, str> {
+        self.descriptor().name().unwrap_or("compatible type").into()
     }
 }
 

--- a/deser/src/macros.rs
+++ b/deser/src/macros.rs
@@ -4,17 +4,17 @@ macro_rules! extend_lifetime {
     };
 }
 
-/// Creates a typed slot wrapper.
+/// Creates a newtype wrapper around `Option<T>`.
 ///
-/// Slot wrappers are required to implement deserialization.  For
-/// more information see [`de`](crate::de).  To see the generated
+/// Slot wrappers are useful to implement deserialization when stateless
+/// deserialization is an option.  This way an allocation is avoided.
+/// For more information see [`de`](crate::de).  To see the generated
 /// slot wrapper API see [`SlotWrapper`](crate::de::SlotWrapper).
 ///
 /// ## Example
 ///
 /// ```rust
-/// use deser::make_slot_wrapper;
-/// make_slot_wrapper!(SlotWrapper);
+/// deser::make_slot_wrapper!(SlotWrapper);
 /// ```
 #[macro_export]
 macro_rules! make_slot_wrapper {

--- a/deser/src/ser/impls.rs
+++ b/deser/src/ser/impls.rs
@@ -20,7 +20,7 @@ impl Serialize for bool {
 
 impl Serialize for () {
     fn descriptor(&self) -> &dyn Descriptor {
-        static DESCRIPTOR: NamedDescriptor = NamedDescriptor { name: "()" };
+        static DESCRIPTOR: NamedDescriptor = NamedDescriptor { name: "null" };
         &DESCRIPTOR
     }
 

--- a/deser/src/ser/mod.rs
+++ b/deser/src/ser/mod.rs
@@ -400,11 +400,6 @@ pub trait SeqEmitter {
 ///   compound values like lists or similar, the piece contains a boxed emitter
 ///   which can be further processed to walk the embedded compound value.
 pub trait Serialize {
-    /// Returns the descriptor of this serializable if it exists.
-    fn descriptor(&self) -> &dyn Descriptor {
-        &NullDescriptor
-    }
-
     /// Serializes this serializable.
     fn serialize(&self, state: &SerializerState) -> Result<Chunk, Error>;
 
@@ -426,6 +421,11 @@ pub trait Serialize {
     /// the struct.
     fn is_optional(&self) -> bool {
         false
+    }
+
+    /// Returns the descriptor of this serializable if it exists.
+    fn descriptor(&self) -> &dyn Descriptor {
+        &NullDescriptor
     }
 
     /// Hidden internal trait method to allow specializations of bytes.

--- a/examples/manual-struct/src/main.rs
+++ b/examples/manual-struct/src/main.rs
@@ -1,11 +1,9 @@
 use std::borrow::Cow;
 
-use deser::de::{DeserializerState, Driver, MapSink, Sink, SinkHandle};
+use deser::de::{DeserializerState, Driver, Sink, SinkHandle};
 use deser::ser::{Chunk, SerializeHandle, SerializerState, StructEmitter};
-use deser::{make_slot_wrapper, Descriptor, Deserialize, Error, ErrorKind, Event, Serialize};
+use deser::{Descriptor, Deserialize, Error, ErrorKind, Event, Serialize};
 use deser_debug::ToDebug;
-
-make_slot_wrapper!(SlotWrapper);
 
 pub struct User {
     id: usize,
@@ -55,18 +53,12 @@ impl<'a> StructEmitter for UserEmitter<'a> {
 
 impl Deserialize for User {
     fn deserialize_into(out: &mut Option<Self>) -> SinkHandle {
-        SlotWrapper::make_handle(out)
-    }
-}
-
-impl Sink for SlotWrapper<User> {
-    fn old_map(&mut self, _state: &DeserializerState) -> Result<Box<dyn MapSink + '_>, Error> {
-        Ok(Box::new(UserSink {
-            out: self,
+        SinkHandle::boxed(UserSink {
+            out,
             key: None,
             id: None,
             email_address: None,
-        }))
+        })
     }
 }
 
@@ -77,16 +69,20 @@ struct UserSink<'a> {
     email_address: Option<String>,
 }
 
-impl<'a> MapSink for UserSink<'a> {
+impl<'a> Sink for UserSink<'a> {
     fn descriptor(&self) -> &dyn Descriptor {
         &UserDescriptor
     }
 
-    fn key(&mut self) -> Result<SinkHandle, Error> {
+    fn map(&mut self, _state: &DeserializerState) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn next_key(&mut self) -> Result<SinkHandle, Error> {
         Ok(Deserialize::deserialize_into(&mut self.key))
     }
 
-    fn value(&mut self) -> Result<SinkHandle, Error> {
+    fn next_value(&mut self) -> Result<SinkHandle, Error> {
         match self.key.take().as_deref() {
             Some("id") => Ok(Deserialize::deserialize_into(&mut self.id)),
             Some("emailAddress") => Ok(Deserialize::deserialize_into(&mut self.email_address)),

--- a/examples/manual-struct/src/main.rs
+++ b/examples/manual-struct/src/main.rs
@@ -60,7 +60,7 @@ impl Deserialize for User {
 }
 
 impl Sink for SlotWrapper<User> {
-    fn map(&mut self, _state: &DeserializerState) -> Result<Box<dyn MapSink + '_>, Error> {
+    fn old_map(&mut self, _state: &DeserializerState) -> Result<Box<dyn MapSink + '_>, Error> {
         Ok(Box::new(UserSink {
             out: self,
             key: None,


### PR DESCRIPTION
This removes `MapSink` and `SeqSink`. With this change some new patterns become possible and the cognitive overhead of the API gets slightly reduced.

Additionally descriptors are now always available on deserialization and `finish` is called on all values on the sink.

Fixes #14