### PR TITLE
Add basic struct flattening support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to deser are documented here.
   directly on the `Sink`.
 - The serializer state and deserializer state is now passed to `next_key`/
   `next_value` and `next` on the sinks and emitters.
+- Added support for `#[deser(flatten)]`.
 
 ## 0.5.0
 

--- a/deser-derive/src/attr.rs
+++ b/deser-derive/src/attr.rs
@@ -352,12 +352,6 @@ impl<'a> FieldAttrs<'a> {
                 "cannot combine flatten and default",
             ));
         }
-        if rv.flatten && rv.skip_serializing_if.is_some() {
-            return Err(syn::Error::new_spanned(
-                field,
-                "cannot combine flatten and skip_serializing_if",
-            ));
-        }
 
         Ok(rv)
     }

--- a/deser-derive/src/attr.rs
+++ b/deser-derive/src/attr.rs
@@ -352,6 +352,12 @@ impl<'a> FieldAttrs<'a> {
                 "cannot combine flatten and default",
             ));
         }
+        if rv.flatten && rv.skip_serializing_if.is_some() {
+            return Err(syn::Error::new_spanned(
+                field,
+                "cannot combine flatten and skip_serializing_if",
+            ));
+        }
 
         Ok(rv)
     }

--- a/deser-derive/src/de.rs
+++ b/deser-derive/src/de.rs
@@ -243,7 +243,7 @@ fn derive_struct(input: &syn::DeriveInput, fields: &syn::FieldsNamed) -> syn::Re
                     -> ::deser::__derive::Result<::deser::de::SinkHandle>
                 {
                     let __key = self.key.take().unwrap();
-                    ::deser::__derive::Ok(match self.value_for_key(&__key) {
+                    ::deser::__derive::Ok(match self.value_for_key(&__key, __state) {
                         ::deser::__derive::Some(__sink) => __sink,
                         ::deser::__derive::None => ::deser::de::SinkHandle::null(),
                     })

--- a/deser-derive/src/de.rs
+++ b/deser-derive/src/de.rs
@@ -243,28 +243,28 @@ fn derive_struct(input: &syn::DeriveInput, fields: &syn::FieldsNamed) -> syn::Re
                     -> ::deser::__derive::Result<::deser::de::SinkHandle>
                 {
                     let __key = self.key.take().unwrap();
-                    ::deser::__derive::Ok(match self.value_for_key(&__key, __state) {
+                    ::deser::__derive::Ok(match self.value_for_key(&__key, __state)? {
                         ::deser::__derive::Some(__sink) => __sink,
                         ::deser::__derive::None => ::deser::de::SinkHandle::null(),
                     })
                 }
 
                 fn value_for_key(&mut self, __key: &str, __state: &::deser::de::DeserializerState)
-                    -> ::deser::__derive::Option<::deser::de::SinkHandle>
+                    -> ::deser::__derive::Result<::deser::__derive::Option<::deser::de::SinkHandle>>
                 {
                     match __key {
                         #(
-                            #matcher => return ::deser::__derive::Some(::deser::Deserialize::deserialize_into(&mut self.#sink_fieldname)),
+                            #matcher => return ::deser::__derive::Ok(::deser::__derive::Some(::deser::Deserialize::deserialize_into(&mut self.#sink_fieldname))),
                         )*
                         __other => {
                             #(
-                                if let ::deser::__derive::Some(__sink) = self.#flatten_fields.borrow_mut().value_for_key(__other, __state) {
-                                    return ::deser::__derive::Some(__sink);
+                                if let ::deser::__derive::Some(__sink) = self.#flatten_fields.borrow_mut().value_for_key(__other, __state)? {
+                                    return ::deser::__derive::Ok(::deser::__derive::Some(__sink));
                                 }
                             )*
                         }
                     }
-                    ::deser::__derive::None
+                    ::deser::__derive::Ok(::deser::__derive::None)
                 }
 
                 fn finish(&mut self, __state: &::deser::de::DeserializerState) -> ::deser::__derive::Result<()> {

--- a/deser-derive/src/ser.rs
+++ b/deser-derive/src/ser.rs
@@ -136,7 +136,7 @@ fn derive_struct(input: &syn::DeriveInput, fields: &syn::FieldsNamed) -> syn::Re
 
             impl #wrapper_impl_generics ::deser::ser::StructEmitter for __StructEmitter #wrapper_ty_generics #bounded_where_clause {
                 fn next(&mut self, __state: &::deser::ser::SerializerState)
-                    -> ::deser::__derive::Option<(deser::__derive::StrCow, ::deser::ser::SerializeHandle)>
+                    -> ::deser::__derive::Result<::deser::__derive::Option<(deser::__derive::StrCow, ::deser::ser::SerializeHandle)>>
                 {
                     loop {
                         let __index = self.index;
@@ -146,13 +146,13 @@ fn derive_struct(input: &syn::DeriveInput, fields: &syn::FieldsNamed) -> syn::Re
                                     self.index = __index + 1;
                                     let __handle = ::deser::ser::SerializeHandle::to(&self.data.#fieldname);
                                     #skip_if
-                                    return::deser::__derive::Some((
+                                    return ::deser::__derive::Ok(::deser::__derive::Some((
                                         ::deser::__derive::Cow::Borrowed(#fieldstr),
                                         __handle,
-                                    ))
+                                    )));
                                 }
                             )*
-                            _ => return ::deser::__derive::None,
+                            _ => return ::deser::__derive::Ok(::deser::__derive::None),
                         }
                     }
                 }

--- a/deser-derive/src/ser.rs
+++ b/deser-derive/src/ser.rs
@@ -103,6 +103,7 @@ fn derive_struct(input: &syn::DeriveInput, fields: &syn::FieldsNamed) -> syn::Re
                             ::deser::__derive::None => {
                                 self.index += 1;
                                 self.nested_emitter_exhausted = true;
+                                self.data.#name.finish(__state)?;
                                 continue;
                             }
                             // we need this transmute here because of limitations in the borrow

--- a/deser-derive/src/ser.rs
+++ b/deser-derive/src/ser.rs
@@ -25,69 +25,101 @@ fn derive_struct(input: &syn::DeriveInput, fields: &syn::FieldsNamed) -> syn::Re
 
     let container_attrs = ContainerAttrs::of(input)?;
     let type_name = container_attrs.container_name();
-    let fieldname = &fields.named.iter().map(|f| &f.ident).collect::<Vec<_>>();
     let attrs = fields
         .named
         .iter()
         .map(FieldAttrs::of)
         .collect::<syn::Result<Vec<_>>>()?;
-    let fieldstr = attrs
-        .iter()
-        .map(|x| x.name(&container_attrs))
-        .collect::<Vec<_>>();
-    let skip_if = attrs
-        .iter()
-        .zip(fieldname.iter())
-        .map(|(attrs, name)| {
-            let field_skip = if let Some(path) = attrs.skip_serializing_if() {
-                quote! {
-                    if #path(&self.data.#name) {
-                        continue;
-                    }
-                }
-            } else {
-                quote! {}
-            };
-            let optional_skip = if container_attrs.skip_serializing_optionals() {
-                quote! {
-                    if __handle.is_optional() {
-                        continue;
-                    }
-                }
-            } else {
-                quote! {}
-            };
-            quote! {
-                #field_skip
-                #optional_skip
-            }
-        })
-        .collect::<Vec<_>>();
-    let nested_emitters = attrs
-        .iter()
-        .filter_map(|attrs| {
-            if attrs.flatten() {
-                Some(syn::Ident::new(
-                    &format!("emitter_{}", attrs.field().ident.as_ref().unwrap()),
-                    Span::call_site(),
-                ))
-            } else {
-                None
-            }
-        })
-        .collect::<Vec<_>>();
-    let nested_emitters_fields = attrs
-        .iter()
-        .filter_map(|attrs| {
-            if attrs.flatten() {
-                Some(attrs.field().ident.as_ref().unwrap())
-            } else {
-                None
-            }
-        })
-        .collect::<Vec<_>>();
 
-    let index = 0usize..;
+    let temp_emitter = if attrs.iter().any(|x| x.flatten()) {
+        Some(quote! {
+            nested_emitter: ::deser::__derive::Option<::deser::__derive::Box<dyn ::deser::ser::StructEmitter + '__a>>,
+            nested_emitter_exhausted: bool,
+        })
+    } else {
+        None
+    };
+    let temp_emitter_init = if attrs.iter().any(|x| x.flatten()) {
+        Some(quote! {
+            nested_emitter: ::deser::__derive::None,
+            nested_emitter_exhausted: true,
+        })
+    } else {
+        None
+    };
+    let state_handler = attrs
+        .iter()
+        .enumerate()
+        .map(|(index, attrs)| {
+            let name = &attrs.field().ident;
+            if !attrs.flatten() {
+                let fieldstr = attrs.name(&container_attrs);
+                let field_skip = if let Some(path) = attrs.skip_serializing_if() {
+                    quote! {
+                        if #path(&self.data.#name) {
+                            continue;
+                        }
+                    }
+                } else {
+                    quote! {}
+                };
+                let optional_skip = if container_attrs.skip_serializing_optionals() {
+                    quote! {
+                        if __handle.is_optional() {
+                            continue;
+                        }
+                    }
+                } else {
+                    quote! {}
+                };
+                quote! {
+                    #index => {
+                        self.index = __index + 1;
+                        let __handle = ::deser::ser::SerializeHandle::to(&self.data.#name);
+                        #field_skip
+                        #optional_skip
+                        return ::deser::__derive::Ok(::deser::__derive::Some((
+                            ::deser::__derive::Cow::Borrowed(#fieldstr),
+                            __handle,
+                        )));
+                    }
+                }
+            } else {
+                quote! {
+                    #index => {
+                        if self.nested_emitter_exhausted {
+                            self.nested_emitter = match self.data.#name.serialize(__state)? {
+                                ::deser::ser::Chunk::Struct(__inner) => {
+                                    Some(__inner)
+                                }
+                                _ => return ::deser::__derive::Err(::deser::Error::new(
+                                    ::deser::ErrorKind::Unexpected,
+                                    "unable to flatten on struct into struct"
+                                ))
+                            };
+                            self.nested_emitter_exhausted = false;
+                        }
+                        match self.nested_emitter.as_mut().unwrap().next(__state)? {
+                            ::deser::__derive::None => {
+                                self.index += 1;
+                                self.nested_emitter_exhausted = true;
+                                continue;
+                            }
+                            // we need this transmute here because of limitations in the borrow
+                            // checker.  The borrow checker does not understand that the borrow
+                            // does not continue into the next loop iteration.  If polonius ever
+                            // makes it into Rust this can go.
+                            //
+                            // This can be validated with `-Zpolonius`
+                            __item => return ::deser::__derive::Ok(unsafe {
+                                ::std::mem::transmute::<_, _>(__item)
+                            }),
+                        }
+                    }
+                }
+            }
+        })
+        .collect::<Vec<_>>();
 
     let wrapper_generics = with_lifetime_bound(&input.generics, "'__a");
     let (wrapper_impl_generics, wrapper_ty_generics, _) = wrapper_generics.split_for_impl();
@@ -105,15 +137,7 @@ fn derive_struct(input: &syn::DeriveInput, fields: &syn::FieldsNamed) -> syn::Re
                     ::deser::__derive::Ok(::deser::ser::Chunk::Struct(Box::new(__StructEmitter {
                         data: self,
                         index: 0,
-                        #(
-                            #nested_emitters: match self.#nested_emitters_fields.serialize(__state)? {
-                                ::deser::ser::Chunk::Struct(emitter) => emitter,
-                                _ => return ::deser::__derive::Err(::deser::Error::new(
-                                    ::deser::ErrorKind::Unexpected,
-                                    "cannot flatten non-struct types"
-                                ))
-                            },
-                        )*
+                        #temp_emitter_init
                     })))
                 }
             }
@@ -121,9 +145,7 @@ fn derive_struct(input: &syn::DeriveInput, fields: &syn::FieldsNamed) -> syn::Re
             struct __StructEmitter #wrapper_impl_generics #where_clause {
                 data: &'__a #ident #ty_generics,
                 index: usize,
-                #(
-                    #nested_emitters: Box<dyn ::deser::ser::StructEmitter + '__a>,
-                )*
+                #temp_emitter
             }
 
             struct __Descriptor;
@@ -138,19 +160,12 @@ fn derive_struct(input: &syn::DeriveInput, fields: &syn::FieldsNamed) -> syn::Re
                 fn next(&mut self, __state: &::deser::ser::SerializerState)
                     -> ::deser::__derive::Result<::deser::__derive::Option<(deser::__derive::StrCow, ::deser::ser::SerializeHandle)>>
                 {
+                    #[allow(clippy::never_loop)]
                     loop {
                         let __index = self.index;
                         match __index {
                             #(
-                                #index => {
-                                    self.index = __index + 1;
-                                    let __handle = ::deser::ser::SerializeHandle::to(&self.data.#fieldname);
-                                    #skip_if
-                                    return ::deser::__derive::Ok(::deser::__derive::Some((
-                                        ::deser::__derive::Cow::Borrowed(#fieldstr),
-                                        __handle,
-                                    )));
-                                }
+                                #state_handler
                             )*
                             _ => return ::deser::__derive::Ok(::deser::__derive::None),
                         }

--- a/deser/src/de/mod.rs
+++ b/deser/src/de/mod.rs
@@ -357,10 +357,14 @@ pub trait Sink {
     /// if they want to support flattening.  A struct that gets flattened into
     /// another struct will have this method called to figure out if a key is
     /// used by it.  The default implementation always returns `None`.
-    fn value_for_key(&mut self, key: &str, state: &DeserializerState) -> Option<SinkHandle> {
+    fn value_for_key(
+        &mut self,
+        key: &str,
+        state: &DeserializerState,
+    ) -> Result<Option<SinkHandle>, Error> {
         let _ = key;
         let _ = state;
-        None
+        Ok(None)
     }
 
     /// Called after [`atom`](Self::atom), [`map`](Self::map) or [`seq](Self::seq).

--- a/deser/src/de/mod.rs
+++ b/deser/src/de/mod.rs
@@ -190,6 +190,9 @@ use crate::extensions::Extensions;
 
 mod ignore;
 mod impls;
+mod owned;
+
+pub use self::owned::OwnedSink;
 
 __make_slot_wrapper!((pub), SlotWrapper);
 
@@ -344,6 +347,17 @@ pub trait Sink {
     /// Returns a sink for the next value in a map or sequence.
     fn next_value(&mut self) -> Result<SinkHandle, Error> {
         Ok(SinkHandle::null())
+    }
+
+    /// Returns a value sink for a specific struct field.
+    ///
+    /// This is a special method that is supposed to be implemented by structs
+    /// if they want to support flattening.  A struct that gets flattened into
+    /// another struct will have this method called to figure out if a key is
+    /// used by it.  The default implementation always returns `None`.
+    fn value_for_key(&mut self, key: &str) -> Option<SinkHandle> {
+        let _ = key;
+        None
     }
 
     /// Called after [`atom`](Self::atom), [`map`](Self::map) or [`seq](Self::seq).

--- a/deser/src/de/owned.rs
+++ b/deser/src/de/owned.rs
@@ -1,0 +1,99 @@
+use std::mem::{transmute, ManuallyDrop};
+use std::ops::{Deref, DerefMut};
+use std::ptr::NonNull;
+
+use crate::de::{Deserialize, SinkHandle};
+
+struct NonuniqueBox<T: ?Sized> {
+    ptr: NonNull<T>,
+}
+
+impl<T> NonuniqueBox<T> {
+    pub fn new(value: T) -> Self {
+        NonuniqueBox::from(Box::new(value))
+    }
+}
+
+impl<T: ?Sized> From<Box<T>> for NonuniqueBox<T> {
+    fn from(boxed: Box<T>) -> Self {
+        let ptr = Box::into_raw(boxed);
+        let ptr = unsafe { NonNull::new_unchecked(ptr) };
+        NonuniqueBox { ptr }
+    }
+}
+
+impl<T: ?Sized> Deref for NonuniqueBox<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        unsafe { self.ptr.as_ref() }
+    }
+}
+
+impl<T: ?Sized> DerefMut for NonuniqueBox<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { self.ptr.as_mut() }
+    }
+}
+
+impl<T: ?Sized> Drop for NonuniqueBox<T> {
+    fn drop(&mut self) {
+        let ptr = self.ptr.as_ptr();
+        let _ = unsafe { Box::from_raw(ptr) };
+    }
+}
+
+/// Utility to bundle a sink with a slot.
+///
+/// There are situations where one wants to be able to deserialize into
+/// a slot that needs to be allocated on the heap and hold it together
+/// with the sink handle.  Rust's lifetimes make this impossible so this
+/// abstraction is provided to allow this.
+pub struct OwnedSink<T> {
+    storage: NonuniqueBox<Option<T>>,
+    sink: Option<ManuallyDrop<SinkHandle<'static>>>,
+}
+
+impl<T: Deserialize> OwnedSink<T> {
+    /// Creates a new owned sink for a given type.
+    ///
+    /// This begins the deserialization with [`Deserialize::deserialize_into`]
+    /// into a slot contained within the owned sink.  To extract the final
+    /// value use [`take`](Self::take).
+    pub fn deserialize() -> OwnedSink<T> {
+        let mut storage = NonuniqueBox::new(None);
+        unsafe {
+            let ptr = transmute::<_, &mut Option<T>>(&mut *storage);
+            let sink = extend_lifetime!(T::deserialize_into(ptr), SinkHandle<'_>);
+            OwnedSink {
+                storage,
+                sink: Some(ManuallyDrop::new(extend_lifetime!(sink, SinkHandle<'_>))),
+            }
+        }
+    }
+
+    /// Immutably borrows from an owned sink.
+    pub fn borrow(&mut self) -> &SinkHandle<'_> {
+        unsafe { extend_lifetime!(self.sink.as_ref().unwrap(), &SinkHandle<'_>) }
+    }
+
+    /// Mutably borrows from the owned sink.
+    #[allow(clippy::should_implement_trait)]
+    pub fn borrow_mut(&mut self) -> &mut SinkHandle<'_> {
+        unsafe { extend_lifetime!(self.sink.as_mut().unwrap(), &mut SinkHandle<'_>) }
+    }
+
+    /// Takes the value produced by the sink.
+    pub fn take(&mut self) -> Option<T> {
+        self.storage.take()
+    }
+}
+
+impl<T> Drop for OwnedSink<T> {
+    fn drop(&mut self) {
+        unsafe {
+            if let Some(ref mut sink) = self.sink.take() {
+                ManuallyDrop::drop(sink);
+            }
+        }
+    }
+}

--- a/deser/src/derive.rs
+++ b/deser/src/derive.rs
@@ -64,6 +64,9 @@
 //!   if it should be skipped during serialization.
 //! * `#[deser(alias = "...")]`: provides an alias for the field name for deserialization.  This is ignored
 //!   for serialization.
+//! * `#[deser(flatten)]`: when added to a nested struct field causes that field to be flattened into the
+//!   parent struct.  Note that flattening only works with structs (more specifically with string) keys.
+//!   This feature is enabled by [`value_for_key`](crate::de::Sink::value_for_key).
 //!
 //! ## Enum Variant Attributes
 //!

--- a/deser/src/ser/impls.rs
+++ b/deser/src/ser/impls.rs
@@ -174,8 +174,8 @@ where
 struct SliceEmitter<'a, T>(std::slice::Iter<'a, T>);
 
 impl<'a, T: Serialize> SeqEmitter for SliceEmitter<'a, T> {
-    fn next(&mut self, _state: &SerializerState) -> Option<SerializeHandle> {
-        self.0.next().map(SerializeHandle::to)
+    fn next(&mut self, _state: &SerializerState) -> Result<Option<SerializeHandle>, Error> {
+        Ok(self.0.next().map(SerializeHandle::to))
     }
 }
 
@@ -197,15 +197,18 @@ where
             K: Serialize,
             V: Serialize,
         {
-            fn next_key(&mut self, _state: &SerializerState) -> Option<SerializeHandle> {
-                self.0.next().map(|(k, v)| {
+            fn next_key(
+                &mut self,
+                _state: &SerializerState,
+            ) -> Result<Option<SerializeHandle>, Error> {
+                Ok(self.0.next().map(|(k, v)| {
                     self.1 = Some(v);
                     SerializeHandle::to(k)
-                })
+                }))
             }
 
-            fn next_value(&mut self, _state: &SerializerState) -> SerializeHandle {
-                SerializeHandle::to(self.1.unwrap())
+            fn next_value(&mut self, _state: &SerializerState) -> Result<SerializeHandle, Error> {
+                Ok(SerializeHandle::to(self.1.unwrap()))
             }
         }
 
@@ -232,15 +235,18 @@ where
             K: Serialize,
             V: Serialize,
         {
-            fn next_key(&mut self, _state: &SerializerState) -> Option<SerializeHandle> {
-                self.0.next().map(|(k, v)| {
+            fn next_key(
+                &mut self,
+                _state: &SerializerState,
+            ) -> Result<Option<SerializeHandle>, Error> {
+                Ok(self.0.next().map(|(k, v)| {
                     self.1 = Some(v);
                     SerializeHandle::to(k)
-                })
+                }))
             }
 
-            fn next_value(&mut self, _state: &SerializerState) -> SerializeHandle {
-                SerializeHandle::to(self.1.unwrap())
+            fn next_value(&mut self, _state: &SerializerState) -> Result<SerializeHandle, Error> {
+                Ok(SerializeHandle::to(self.1.unwrap()))
             }
         }
 
@@ -264,8 +270,8 @@ where
         where
             T: Serialize,
         {
-            fn next(&mut self, _state: &SerializerState) -> Option<SerializeHandle> {
-                self.0.next().map(SerializeHandle::to)
+            fn next(&mut self, _state: &SerializerState) -> Result<Option<SerializeHandle>, Error> {
+                Ok(self.0.next().map(SerializeHandle::to))
             }
         }
 
@@ -289,8 +295,8 @@ where
         where
             T: Serialize,
         {
-            fn next(&mut self, _state: &SerializerState) -> Option<SerializeHandle> {
-                self.0.next().map(SerializeHandle::to)
+            fn next(&mut self, _state: &SerializerState) -> Result<Option<SerializeHandle>, Error> {
+                Ok(self.0.next().map(SerializeHandle::to))
             }
         }
 
@@ -339,18 +345,18 @@ macro_rules! serialize_for_tuple {
                 where
                     $($name: Serialize,)*
                 {
-                    fn next(&mut self,_state: &SerializerState) -> Option<SerializeHandle> {
+                    fn next(&mut self,_state: &SerializerState) -> Result<Option<SerializeHandle>, Error> {
                         let ($(ref $name,)*) = self.tuple;
                         let __index = self.index;
                         self.index += 1;
                         let mut __counter = 0;
                         $(
                             if __index == __counter {
-                                return Some(SerializeHandle::to($name));
+                                return Ok(Some(SerializeHandle::to($name)));
                             }
                             __counter += 1;
                         )*
-                        None
+                        Ok(None)
                     }
                 }
 

--- a/deser/tests/test_custom_map.rs
+++ b/deser/tests/test_custom_map.rs
@@ -19,17 +19,17 @@ pub struct FlagsMapEmitter<'a> {
 }
 
 impl<'a> MapEmitter for FlagsMapEmitter<'a> {
-    fn next_key(&mut self, _state: &SerializerState) -> Option<SerializeHandle> {
-        if let Some((key, value)) = self.iter.next() {
+    fn next_key(&mut self, _state: &SerializerState) -> Result<Option<SerializeHandle>, Error> {
+        Ok(if let Some((key, value)) = self.iter.next() {
             self.value = Some(value);
             Some(SerializeHandle::boxed(key.to_string()))
         } else {
             None
-        }
+        })
     }
 
-    fn next_value(&mut self, _state: &SerializerState) -> SerializeHandle {
-        SerializeHandle::to(self.value.unwrap())
+    fn next_value(&mut self, _state: &SerializerState) -> Result<SerializeHandle, Error> {
+        Ok(SerializeHandle::to(self.value.unwrap()))
     }
 }
 

--- a/deser/tests/test_de_derive.rs
+++ b/deser/tests/test_de_derive.rs
@@ -358,3 +358,67 @@ fn test_variant_alias() {
     let s: Stuff = deserialize(vec!["alpha".into()]);
     assert_eq!(s, Stuff::A);
 }
+
+#[test]
+fn test_flatten_basics() {
+    #![allow(dead_code)]
+
+    #[derive(Deserialize, PartialEq, Eq, Debug)]
+    struct Test {
+        a: usize,
+        b: usize,
+        #[deser(flatten)]
+        inner1: Inner1,
+        #[deser(flatten)]
+        inner2: Inner2,
+        c: usize,
+    }
+
+    #[derive(Deserialize, PartialEq, Eq, Debug)]
+    struct Inner1 {
+        inner1_a: usize,
+        inner1_b: usize,
+    }
+
+    #[derive(Deserialize, PartialEq, Eq, Debug)]
+    struct Inner2 {
+        inner2_a: usize,
+        inner2_b: usize,
+    }
+
+    let s: Test = deserialize(vec![
+        Event::MapStart,
+        "a".into(),
+        1u64.into(),
+        "b".into(),
+        2u64.into(),
+        "inner1_a".into(),
+        99u64.into(),
+        "inner1_b".into(),
+        100u64.into(),
+        "inner2_a".into(),
+        199u64.into(),
+        "inner2_b".into(),
+        200u64.into(),
+        "c".into(),
+        3u64.into(),
+        Event::MapEnd,
+    ]);
+
+    assert_eq!(
+        s,
+        Test {
+            a: 1,
+            b: 2,
+            c: 3,
+            inner1: Inner1 {
+                inner1_a: 99,
+                inner1_b: 100,
+            },
+            inner2: Inner2 {
+                inner2_a: 199,
+                inner2_b: 200,
+            },
+        }
+    );
+}

--- a/deser/tests/test_de_derive.rs
+++ b/deser/tests/test_de_derive.rs
@@ -361,8 +361,6 @@ fn test_variant_alias() {
 
 #[test]
 fn test_flatten_basics() {
-    #![allow(dead_code)]
-
     #[derive(Deserialize, PartialEq, Eq, Debug)]
     struct Test {
         a: usize,
@@ -421,4 +419,27 @@ fn test_flatten_basics() {
             },
         }
     );
+}
+
+#[test]
+#[should_panic = "Missing field 'b'"]
+fn test_flatten_incomplete_inner() {
+    #[derive(Deserialize, PartialEq, Eq, Debug)]
+    struct Test {
+        a: usize,
+        #[deser(flatten)]
+        inner: Inner,
+    }
+
+    #[derive(Deserialize, PartialEq, Eq, Debug)]
+    struct Inner {
+        b: usize,
+    }
+
+    let _: Test = deserialize(vec![
+        Event::MapStart,
+        "a".into(),
+        1u64.into(),
+        Event::MapEnd,
+    ]);
 }

--- a/deser/tests/test_ser_derive.rs
+++ b/deser/tests/test_ser_derive.rs
@@ -84,3 +84,63 @@ fn test_skip_serializing_optionals_some() {
         vec![Event::MapStart, "b".into(), 2u64.into(), Event::MapEnd]
     );
 }
+
+#[test]
+fn test_flatten_basics() {
+    #[derive(Serialize)]
+    struct Test {
+        a: usize,
+        b: usize,
+        #[deser(flatten)]
+        inner1: Inner1,
+        #[deser(flatten)]
+        inner2: Inner2,
+        c: usize,
+    }
+
+    #[derive(Serialize)]
+    struct Inner1 {
+        inner1_a: usize,
+        inner1_b: usize,
+    }
+
+    #[derive(Serialize)]
+    struct Inner2 {
+        inner2_a: usize,
+        inner2_b: usize,
+    }
+
+    assert_eq!(
+        serialize(&Test {
+            a: 1,
+            b: 2,
+            c: 3,
+            inner1: Inner1 {
+                inner1_a: 99,
+                inner1_b: 100,
+            },
+            inner2: Inner2 {
+                inner2_a: 199,
+                inner2_b: 200,
+            },
+        }),
+        vec![
+            Event::MapStart,
+            "a".into(),
+            1u64.into(),
+            "b".into(),
+            2u64.into(),
+            "inner1_a".into(),
+            99u64.into(),
+            "inner1_b".into(),
+            100u64.into(),
+            "inner2_a".into(),
+            199u64.into(),
+            "inner2_b".into(),
+            200u64.into(),
+            "c".into(),
+            3u64.into(),
+            Event::MapEnd,
+        ]
+    );
+}

--- a/deser/tests/test_ser_derive.rs
+++ b/deser/tests/test_ser_derive.rs
@@ -144,3 +144,50 @@ fn test_flatten_basics() {
         ]
     );
 }
+
+#[test]
+fn test_flatten_skip_optionals() {
+    #[derive(Serialize)]
+    #[deser(skip_serializing_optionals)]
+    struct Outer {
+        required: bool,
+        first: Option<usize>,
+        #[deser(flatten)]
+        inner: Inner,
+    }
+
+    #[derive(Serialize)]
+    struct Inner {
+        second: Option<usize>,
+    }
+
+    assert_eq!(
+        serialize(&Outer {
+            required: true,
+            first: None,
+            inner: Inner { second: None }
+        }),
+        vec![
+            Event::MapStart,
+            "required".into(),
+            true.into(),
+            Event::MapEnd,
+        ]
+    );
+
+    assert_eq!(
+        serialize(&Outer {
+            required: true,
+            first: None,
+            inner: Inner { second: Some(111) }
+        }),
+        vec![
+            Event::MapStart,
+            "required".into(),
+            true.into(),
+            "second".into(),
+            111u64.into(),
+            Event::MapEnd,
+        ]
+    );
+}

--- a/deser/tests/test_ser_derive.rs
+++ b/deser/tests/test_ser_derive.rs
@@ -191,3 +191,35 @@ fn test_flatten_skip_optionals() {
         ]
     );
 }
+
+#[test]
+fn test_flatten_skip_serializing_if() {
+    fn not_inner(_inner: &Inner) -> bool {
+        true
+    }
+
+    #[derive(Serialize)]
+    struct Outer {
+        required: bool,
+        #[deser(flatten, skip_serializing_if = "not_inner")]
+        inner: Inner,
+    }
+
+    #[derive(Serialize)]
+    struct Inner {
+        second: usize,
+    }
+
+    assert_eq!(
+        serialize(&Outer {
+            required: true,
+            inner: Inner { second: 42 }
+        }),
+        vec![
+            Event::MapStart,
+            "required".into(),
+            true.into(),
+            Event::MapEnd,
+        ]
+    );
+}

--- a/deser/tests/test_ser_derive.rs
+++ b/deser/tests/test_ser_derive.rs
@@ -194,8 +194,8 @@ fn test_flatten_skip_optionals() {
 
 #[test]
 fn test_flatten_skip_serializing_if() {
-    fn not_inner(_inner: &Inner) -> bool {
-        true
+    fn not_inner(inner: &Inner) -> bool {
+        inner.second == 42
     }
 
     #[derive(Serialize)]
@@ -219,6 +219,21 @@ fn test_flatten_skip_serializing_if() {
             Event::MapStart,
             "required".into(),
             true.into(),
+            Event::MapEnd,
+        ]
+    );
+
+    assert_eq!(
+        serialize(&Outer {
+            required: true,
+            inner: Inner { second: 23 }
+        }),
+        vec![
+            Event::MapStart,
+            "required".into(),
+            true.into(),
+            "second".into(),
+            23u64.into(),
             Event::MapEnd,
         ]
     );

--- a/examples/derive/src/main.rs
+++ b/examples/derive/src/main.rs
@@ -8,6 +8,15 @@ pub struct User {
     id: usize,
     email_address: String,
     kind: UserKind,
+    #[deser(flatten)]
+    user_attributes: UserAttributes,
+}
+
+#[derive(Serialize, Deserialize)]
+#[deser(rename_all = "camelCase")]
+struct UserAttributes {
+    is_special: bool,
+    is_powerful: bool,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -28,6 +37,10 @@ fn main() {
         driver.emit("jane@example.com").unwrap();
         driver.emit("kind").unwrap();
         driver.emit("admin").unwrap();
+        driver.emit("isPowerful").unwrap();
+        driver.emit(true).unwrap();
+        driver.emit("isSpecial").unwrap();
+        driver.emit(true).unwrap();
         driver.emit(Event::MapEnd).unwrap();
     }
     println!("{:#?}", ToDebug::new(&user.unwrap()));


### PR DESCRIPTION
This implements basic flattening for flattening (#9). It takes advantage of the recent changes to eliminate the old `MapSink` and `SeqSink` but it needs a new unvetted `OwnedSlot` abstraction to allow deserializing into an adjacent slot.

There is an unsafe transmute in there which only exists because the borrow checker does not really understand loops (https://github.com/rust-lang/rust/issues/54663). I'm not sure if there is a way to get away without the transmute by finding some clever alternative ways to structure this code.

Remaining tasks:

* [x] basic serialize
* [x] basic deserialize
* [x] support combined usage of `skip_serializing_if` and `flatten`
* [x] figure out support for `skip_serializing_optionals` with flatten
* [x] tests