### PR TITLE
Pass state to container advance methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to deser are documented here.
 - Made `Atom` non exhaustive and added `unexpected_atom` to `Deserialize`.
 - Removed `MapSink` and `SeqSink`.  The functionality of these is now
   directly on the `Sink`.
+- The serializer state and deserializer state is now passed to `next_key`/
+  `next_value` and `next` on the sinks and emitters.
 
 ## 0.5.0
 

--- a/deser-derive/src/de.rs
+++ b/deser-derive/src/de.rs
@@ -193,11 +193,15 @@ fn derive_struct(input: &syn::DeriveInput, fields: &syn::FieldsNamed) -> syn::Re
                     ::deser::__derive::Ok(())
                 }
 
-                fn next_key(&mut self) -> ::deser::__derive::Result<::deser::de::SinkHandle> {
+                fn next_key(&mut self, __state: &::deser::de::DeserializerState)
+                    -> ::deser::__derive::Result<::deser::de::SinkHandle>
+                {
                     ::deser::__derive::Ok(::deser::de::Deserialize::deserialize_into(&mut self.key))
                 }
 
-                fn next_value(&mut self) -> ::deser::__derive::Result<::deser::de::SinkHandle> {
+                fn next_value(&mut self, __state: &::deser::de::DeserializerState)
+                    -> ::deser::__derive::Result<::deser::de::SinkHandle>
+                {
                     match self.key.take().as_deref() {
                         #(
                             #matcher => ::deser::__derive::Ok(::deser::Deserialize::deserialize_into(&mut self.#sink_fieldname)),

--- a/deser-derive/src/ser.rs
+++ b/deser-derive/src/ser.rs
@@ -100,7 +100,9 @@ fn derive_struct(input: &syn::DeriveInput, fields: &syn::FieldsNamed) -> syn::Re
             }
 
             impl #wrapper_impl_generics ::deser::ser::StructEmitter for __StructEmitter #wrapper_ty_generics #bounded_where_clause {
-                fn next(&mut self) -> ::deser::__derive::Option<(deser::__derive::StrCow, ::deser::ser::SerializeHandle)> {
+                fn next(&mut self, __state: &::deser::ser::SerializerState)
+                    -> ::deser::__derive::Option<(deser::__derive::StrCow, ::deser::ser::SerializeHandle)>
+                {
                     loop {
                         let __index = self.index;
                         self.index = __index + 1;

--- a/deser-path/src/de.rs
+++ b/deser-path/src/de.rs
@@ -70,8 +70,8 @@ impl<'a> Sink for PathSink<'a> {
         self.sink.seq(state)
     }
 
-    fn next_key(&mut self) -> Result<SinkHandle, Error> {
-        self.sink.next_key().map(|sink| {
+    fn next_key(&mut self, state: &DeserializerState) -> Result<SinkHandle, Error> {
+        self.sink.next_key(state).map(|sink| {
             SinkHandle::boxed(PathSink {
                 sink,
                 container: match self.container {
@@ -83,7 +83,7 @@ impl<'a> Sink for PathSink<'a> {
         })
     }
 
-    fn next_value(&mut self) -> Result<SinkHandle, Error> {
+    fn next_value(&mut self, state: &DeserializerState) -> Result<SinkHandle, Error> {
         let set_segment = match self.container {
             Container::None => None,
             Container::Map(ref captured_key) => captured_key.borrow_mut().take(),
@@ -93,7 +93,7 @@ impl<'a> Sink for PathSink<'a> {
                 Some(PathSegment::Index(old_index))
             }
         };
-        self.sink.next_value().map(|sink| {
+        self.sink.next_value(state).map(|sink| {
             SinkHandle::boxed(PathSink {
                 sink,
                 container: Container::None,

--- a/deser/src/de/ignore.rs
+++ b/deser/src/de/ignore.rs
@@ -17,11 +17,11 @@ impl Sink for Ignore {
         Ok(())
     }
 
-    fn next_key(&mut self) -> Result<SinkHandle, Error> {
+    fn next_key(&mut self, _state: &DeserializerState) -> Result<SinkHandle, Error> {
         Ok(SinkHandle::null())
     }
 
-    fn next_value(&mut self) -> Result<SinkHandle, Error> {
+    fn next_value(&mut self, _state: &DeserializerState) -> Result<SinkHandle, Error> {
         Ok(SinkHandle::null())
     }
 }

--- a/deser/src/de/impls.rs
+++ b/deser/src/de/impls.rs
@@ -263,7 +263,7 @@ impl<T: Deserialize> Deserialize for Vec<T> {
                 Ok(())
             }
 
-            fn next_value(&mut self) -> Result<SinkHandle, Error> {
+            fn next_value(&mut self, _state: &DeserializerState) -> Result<SinkHandle, Error> {
                 self.flush();
                 Ok(Deserialize::deserialize_into(&mut self.element))
             }
@@ -325,12 +325,12 @@ where
                 Ok(())
             }
 
-            fn next_key(&mut self) -> Result<SinkHandle, Error> {
+            fn next_key(&mut self, _state: &DeserializerState) -> Result<SinkHandle, Error> {
                 self.flush();
                 Ok(Deserialize::deserialize_into(&mut self.key))
             }
 
-            fn next_value(&mut self) -> Result<SinkHandle, Error> {
+            fn next_value(&mut self, _state: &DeserializerState) -> Result<SinkHandle, Error> {
                 Ok(Deserialize::deserialize_into(&mut self.value))
             }
 
@@ -388,12 +388,12 @@ where
                 &DESCRIPTOR
             }
 
-            fn next_key(&mut self) -> Result<SinkHandle, Error> {
+            fn next_key(&mut self, _state: &DeserializerState) -> Result<SinkHandle, Error> {
                 self.flush();
                 Ok(Deserialize::deserialize_into(&mut self.key))
             }
 
-            fn next_value(&mut self) -> Result<SinkHandle, Error> {
+            fn next_value(&mut self, _state: &DeserializerState) -> Result<SinkHandle, Error> {
                 Ok(Deserialize::deserialize_into(&mut self.value))
             }
 
@@ -445,12 +445,12 @@ impl<'a> Sink for NullIgnoringSink<'a> {
         self.sink.seq(state)
     }
 
-    fn next_key(&mut self) -> Result<SinkHandle, Error> {
-        self.sink.next_key()
+    fn next_key(&mut self, state: &DeserializerState) -> Result<SinkHandle, Error> {
+        self.sink.next_key(state)
     }
 
-    fn next_value(&mut self) -> Result<SinkHandle, Error> {
-        self.sink.next_value()
+    fn next_value(&mut self, state: &DeserializerState) -> Result<SinkHandle, Error> {
+        self.sink.next_value(state)
     }
 
     fn descriptor(&self) -> &dyn Descriptor {
@@ -483,7 +483,7 @@ macro_rules! deserialize_for_tuple {
                         Ok(())
                     }
 
-                    fn next_value(&mut self) -> Result<SinkHandle, Error> {
+                    fn next_value(&mut self, _state: &DeserializerState) -> Result<SinkHandle, Error> {
                         let __index = self.index;
                         self.index += 1;
                         let mut __counter = 0;
@@ -603,7 +603,7 @@ impl<T: Deserialize, const N: usize> Deserialize for [T; N] {
                 Ok(())
             }
 
-            fn next_value(&mut self) -> Result<SinkHandle, Error> {
+            fn next_value(&mut self, _state: &DeserializerState) -> Result<SinkHandle, Error> {
                 unsafe {
                     self.flush();
                 }

--- a/deser/src/de/mod.rs
+++ b/deser/src/de/mod.rs
@@ -114,14 +114,14 @@
 //!         Ok(())
 //!     }
 //!
-//!     fn next_key(&mut self) -> Result<SinkHandle, Error> {
+//!     fn next_key(&mut self, _state: &DeserializerState) -> Result<SinkHandle, Error> {
 //!         // directly attach to the key field which can hold any
 //!         // string value.  This means that any string is accepted
 //!         // as key.
 //!         Ok(Deserialize::deserialize_into(&mut self.key))
 //!     }
 //!     
-//!     fn next_value(&mut self) -> Result<SinkHandle, Error> {
+//!     fn next_value(&mut self, _state: &DeserializerState) -> Result<SinkHandle, Error> {
 //!         // whenever we are looking for a value slot, look at the last key
 //!         // to decide which value slot to connect.
 //!         match self.key.take().as_deref() {
@@ -180,7 +180,6 @@ use std::borrow::Cow;
 use std::cell::{Ref, RefMut};
 use std::fmt;
 use std::marker::PhantomData;
-use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut};
 
 use crate::descriptors::{Descriptor, NullDescriptor};
@@ -337,12 +336,14 @@ pub trait Sink {
     }
 
     /// Returns a sink for the next key in a map.
-    fn next_key(&mut self) -> Result<SinkHandle, Error> {
+    fn next_key(&mut self, state: &DeserializerState) -> Result<SinkHandle, Error> {
+        let _ = state;
         Ok(SinkHandle::null())
     }
 
     /// Returns a sink for the next value in a map or sequence.
-    fn next_value(&mut self) -> Result<SinkHandle, Error> {
+    fn next_value(&mut self, state: &DeserializerState) -> Result<SinkHandle, Error> {
+        let _ = state;
         Ok(SinkHandle::null())
     }
 
@@ -370,7 +371,7 @@ pub trait Sink {
 /// Gives access to the deserializer state.
 pub struct DeserializerState<'a> {
     extensions: Extensions,
-    stack: ManuallyDrop<Vec<(SinkHandleWrapper, Layer)>>,
+    descriptor_stack: Vec<&'a dyn Descriptor>,
     _marker: PhantomData<&'a Driver<'a>>,
 }
 
@@ -387,14 +388,14 @@ impl<'a> DeserializerState<'a> {
 
     /// Returns the current recursion depth.
     pub fn depth(&self) -> usize {
-        self.stack.len()
+        self.descriptor_stack.len()
     }
 
     /// Returns the topmost descriptor.
     ///
     /// This descriptor always points to a container as the descriptor.
     pub fn top_descriptor(&self) -> Option<&dyn Descriptor> {
-        self.stack.last().map(|x| x.0.sink.descriptor())
+        self.descriptor_stack.last().copied()
     }
 }
 
@@ -405,8 +406,9 @@ impl<'a> DeserializerState<'a> {
 /// internally impossible with safe code, this is a safe abstractiont that
 /// hides the unsafety internally.
 pub struct Driver<'a> {
-    state: ManuallyDrop<DeserializerState<'a>>,
+    state: DeserializerState<'a>,
     current_sink: Option<SinkHandleWrapper>,
+    sink_stack: SinkStack,
 }
 
 struct SinkHandleWrapper {
@@ -428,6 +430,19 @@ enum Layer {
     Seq,
 }
 
+#[derive(Default)]
+struct SinkStack {
+    layers: Vec<(SinkHandleWrapper, Layer)>,
+}
+
+impl Drop for SinkStack {
+    fn drop(&mut self) {
+        while let Some(_item) = self.layers.pop() {
+            // drop in inverse order
+        }
+    }
+}
+
 impl<'a> Driver<'a> {
     /// Creates a new deserializer driver.
     pub fn new<T: Deserialize>(out: &'a mut Option<T>) -> Driver<'a> {
@@ -437,11 +452,12 @@ impl<'a> Driver<'a> {
     /// Creates a new deserializer driver from a sink.
     pub fn from_sink(sink: SinkHandle) -> Driver<'a> {
         Driver {
-            state: ManuallyDrop::new(DeserializerState {
+            state: DeserializerState {
                 extensions: Extensions::default(),
-                stack: ManuallyDrop::new(Vec::new()),
+                descriptor_stack: Vec::new(),
                 _marker: PhantomData,
-            }),
+            },
+            sink_stack: SinkStack::default(),
             current_sink: Some(unsafe { SinkHandleWrapper::from(sink) }),
         }
     }
@@ -467,19 +483,20 @@ impl<'a> Driver<'a> {
     fn _emit(&mut self, event: Event) -> Result<(), Error> {
         macro_rules! target_sink {
             () => {{
-                match self.state.stack.last_mut() {
+                match self.sink_stack.layers.last_mut() {
                     Some((map_sink, Layer::Map(ref mut is_key))) => {
                         let next_sink = if *is_key {
-                            map_sink.sink.next_key()?
+                            map_sink.sink.next_key(&self.state)?
                         } else {
-                            map_sink.sink.next_value()?
+                            map_sink.sink.next_value(&self.state)?
                         };
                         *is_key = !*is_key;
                         self.current_sink = Some(unsafe { SinkHandleWrapper::from(next_sink) });
                     }
                     Some((seq_sink, Layer::Seq)) => {
-                        self.current_sink =
-                            Some(unsafe { SinkHandleWrapper::from(seq_sink.sink.next_value()?) });
+                        self.current_sink = Some(unsafe {
+                            SinkHandleWrapper::from(seq_sink.sink.next_value(&self.state)?)
+                        });
                     }
                     _ => {}
                 }
@@ -501,14 +518,19 @@ impl<'a> Driver<'a> {
             Event::MapStart => {
                 let current_sink = target_sink!();
                 current_sink.map(&self.state)?;
+                let descriptor = current_sink.descriptor();
                 self.state
-                    .stack
+                    .descriptor_stack
+                    .push(unsafe { extend_lifetime!(descriptor, &dyn Descriptor) });
+                self.sink_stack
+                    .layers
                     .push((self.current_sink.take().unwrap(), Layer::Map(true)));
                 return Ok(());
             }
-            Event::MapEnd => match self.state.stack.pop() {
+            Event::MapEnd => match self.sink_stack.layers.pop() {
                 Some((mut map_sink, Layer::Map(_))) => {
                     map_sink.sink.finish(&self.state)?;
+                    self.state.descriptor_stack.pop();
                     self.current_sink = Some(map_sink);
                 }
                 _ => panic!("not inside a MapSink"),
@@ -516,14 +538,19 @@ impl<'a> Driver<'a> {
             Event::SeqStart => {
                 let current_sink = target_sink!();
                 current_sink.seq(&self.state)?;
+                let descriptor = current_sink.descriptor();
                 self.state
-                    .stack
+                    .descriptor_stack
+                    .push(unsafe { extend_lifetime!(descriptor, &dyn Descriptor) });
+                self.sink_stack
+                    .layers
                     .push((self.current_sink.take().unwrap(), Layer::Seq));
                 return Ok(());
             }
-            Event::SeqEnd => match self.state.stack.pop() {
+            Event::SeqEnd => match self.sink_stack.layers.pop() {
                 Some((mut seq_sink, Layer::Seq)) => {
                     seq_sink.sink.finish(&self.state)?;
+                    self.state.descriptor_stack.pop();
                     self.current_sink = Some(seq_sink);
                 }
                 _ => panic!("not inside a SeqSink"),
@@ -533,19 +560,6 @@ impl<'a> Driver<'a> {
         self.current_sink.as_mut().unwrap().used = true;
 
         Ok(())
-    }
-}
-
-impl<'a> Drop for Driver<'a> {
-    fn drop(&mut self) {
-        // it's important that we drop the values in inverse order.
-        while let Some(_last) = self.state.stack.pop() {
-            // drop in inverse order
-        }
-        unsafe {
-            ManuallyDrop::drop(&mut self.state.stack);
-            ManuallyDrop::drop(&mut self.state);
-        }
     }
 }
 

--- a/deser/src/ser/impls.rs
+++ b/deser/src/ser/impls.rs
@@ -174,7 +174,7 @@ where
 struct SliceEmitter<'a, T>(std::slice::Iter<'a, T>);
 
 impl<'a, T: Serialize> SeqEmitter for SliceEmitter<'a, T> {
-    fn next(&mut self) -> Option<SerializeHandle> {
+    fn next(&mut self, _state: &SerializerState) -> Option<SerializeHandle> {
         self.0.next().map(SerializeHandle::to)
     }
 }
@@ -197,14 +197,14 @@ where
             K: Serialize,
             V: Serialize,
         {
-            fn next_key(&mut self) -> Option<SerializeHandle> {
+            fn next_key(&mut self, _state: &SerializerState) -> Option<SerializeHandle> {
                 self.0.next().map(|(k, v)| {
                     self.1 = Some(v);
                     SerializeHandle::to(k)
                 })
             }
 
-            fn next_value(&mut self) -> SerializeHandle {
+            fn next_value(&mut self, _state: &SerializerState) -> SerializeHandle {
                 SerializeHandle::to(self.1.unwrap())
             }
         }
@@ -232,14 +232,14 @@ where
             K: Serialize,
             V: Serialize,
         {
-            fn next_key(&mut self) -> Option<SerializeHandle> {
+            fn next_key(&mut self, _state: &SerializerState) -> Option<SerializeHandle> {
                 self.0.next().map(|(k, v)| {
                     self.1 = Some(v);
                     SerializeHandle::to(k)
                 })
             }
 
-            fn next_value(&mut self) -> SerializeHandle {
+            fn next_value(&mut self, _state: &SerializerState) -> SerializeHandle {
                 SerializeHandle::to(self.1.unwrap())
             }
         }
@@ -264,7 +264,7 @@ where
         where
             T: Serialize,
         {
-            fn next(&mut self) -> Option<SerializeHandle> {
+            fn next(&mut self, _state: &SerializerState) -> Option<SerializeHandle> {
                 self.0.next().map(SerializeHandle::to)
             }
         }
@@ -289,7 +289,7 @@ where
         where
             T: Serialize,
         {
-            fn next(&mut self) -> Option<SerializeHandle> {
+            fn next(&mut self, _state: &SerializerState) -> Option<SerializeHandle> {
                 self.0.next().map(SerializeHandle::to)
             }
         }
@@ -339,7 +339,7 @@ macro_rules! serialize_for_tuple {
                 where
                     $($name: Serialize,)*
                 {
-                    fn next(&mut self) -> Option<SerializeHandle> {
+                    fn next(&mut self,_state: &SerializerState) -> Option<SerializeHandle> {
                         let ($(ref $name,)*) = self.tuple;
                         let __index = self.index;
                         self.index += 1;

--- a/deser/src/ser/mod.rs
+++ b/deser/src/ser/mod.rs
@@ -91,6 +91,7 @@
 use std::borrow::Cow;
 use std::cell::{Ref, RefMut};
 use std::fmt;
+use std::mem::ManuallyDrop;
 use std::ops::Deref;
 
 use crate::descriptors::{Descriptor, NullDescriptor};
@@ -226,13 +227,16 @@ impl<'a> SerializerState<'a> {
 
 #[derive(Default)]
 struct EmitterStack<'a> {
-    layers: Vec<Layer<'a>>,
+    layers: ManuallyDrop<Vec<Layer<'a>>>,
 }
 
 impl<'a> Drop for EmitterStack<'a> {
     fn drop(&mut self) {
         while let Some(_item) = self.layers.pop() {
             // drop in inverse order
+        }
+        unsafe {
+            ManuallyDrop::drop(&mut self.layers);
         }
     }
 }

--- a/deser/tests/test_custom_map.rs
+++ b/deser/tests/test_custom_map.rs
@@ -19,7 +19,7 @@ pub struct FlagsMapEmitter<'a> {
 }
 
 impl<'a> MapEmitter for FlagsMapEmitter<'a> {
-    fn next_key(&mut self) -> Option<SerializeHandle> {
+    fn next_key(&mut self, _state: &SerializerState) -> Option<SerializeHandle> {
         if let Some((key, value)) = self.iter.next() {
             self.value = Some(value);
             Some(SerializeHandle::boxed(key.to_string()))
@@ -28,7 +28,7 @@ impl<'a> MapEmitter for FlagsMapEmitter<'a> {
         }
     }
 
-    fn next_value(&mut self) -> SerializeHandle {
+    fn next_value(&mut self, _state: &SerializerState) -> SerializeHandle {
         SerializeHandle::to(self.value.unwrap())
     }
 }

--- a/examples/manual-struct/src/main.rs
+++ b/examples/manual-struct/src/main.rs
@@ -37,7 +37,7 @@ struct UserEmitter<'a> {
 }
 
 impl<'a> StructEmitter for UserEmitter<'a> {
-    fn next(&mut self) -> Option<(Cow<'_, str>, SerializeHandle)> {
+    fn next(&mut self, _state: &SerializerState) -> Option<(Cow<'_, str>, SerializeHandle)> {
         let index = self.index;
         self.index += 1;
         match index {

--- a/examples/manual-struct/src/main.rs
+++ b/examples/manual-struct/src/main.rs
@@ -78,11 +78,11 @@ impl<'a> Sink for UserSink<'a> {
         Ok(())
     }
 
-    fn next_key(&mut self) -> Result<SinkHandle, Error> {
+    fn next_key(&mut self, _state: &DeserializerState) -> Result<SinkHandle, Error> {
         Ok(Deserialize::deserialize_into(&mut self.key))
     }
 
-    fn next_value(&mut self) -> Result<SinkHandle, Error> {
+    fn next_value(&mut self, _state: &DeserializerState) -> Result<SinkHandle, Error> {
         match self.key.take().as_deref() {
             Some("id") => Ok(Deserialize::deserialize_into(&mut self.id)),
             Some("emailAddress") => Ok(Deserialize::deserialize_into(&mut self.email_address)),


### PR DESCRIPTION
This now passes the serializer and deserializer states to the container advance methods. Internally the use of unsafe is highly questionable and will generally require a review.

This fixes #17 